### PR TITLE
docs: align documentation with actual implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 #     ├── common_system (Tier 0) [REQUIRED] - ILogger, Result<T>
 #     ├── thread_system (Tier 1) [REQUIRED] - Job scheduling
 #     ├── database_system (Tier 2) [REQUIRED] - Database interfaces
-#     ├── network_system (Tier 4) [REQUIRED] - TCP/QUIC server
+#     ├── network_system (Tier 4) [REQUIRED] - TCP server
 #     ├── monitoring_system (Tier 3) [OPTIONAL] - Metrics
 #     └── container_system (Tier 1) [REQUIRED] - Protocol serialization
 ##################################################
@@ -354,7 +354,7 @@ function(link_system_dependency TARGET_NAME DEP_NAME)
             if(MSVC AND "${DEP_NAME}" STREQUAL "NETWORK_SYSTEM")
                 target_link_options(${TARGET_NAME} PUBLIC "/WHOLEARCHIVE:${${DEP_NAME}_LIB}")
                 message(STATUS "Linking ${DEP_NAME} with WHOLEARCHIVE from: ${${DEP_NAME}_LIB}")
-                # Link OpenSSL for HTTP/2, WebSocket, and QUIC support in network_system
+                # Link OpenSSL for HTTP/2 and WebSocket support in network_system
                 find_package(OpenSSL QUIET)
                 if(OPENSSL_FOUND)
                     target_link_libraries(${TARGET_NAME} PUBLIC OpenSSL::SSL OpenSSL::Crypto)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The Database Server is part of the kcenon unified system architecture evolution 
 ├─────────────────────────────────────────────────┤
 │  ┌─────────────┐    ┌─────────────────────┐    │
 │  │   Listener   │───▶│  Auth Middleware    │    │
-│  │ (TCP/QUIC)  │    │  (Rate Limiting)    │    │
+│  │    (TCP)    │    │  (Rate Limiting)    │    │
 │  └─────────────┘    └─────────┬───────────┘    │
 │                               │                 │
 │                    ┌──────────▼──────────┐     │
@@ -51,7 +51,7 @@ The Database Server is part of the kcenon unified system architecture evolution 
 - **common_system** (Tier 0) - Core utilities, Result<T>, logging interfaces
 - **thread_system** (Tier 1) - Job scheduling, thread pool management
 - **database_system** (Tier 2) - Database interfaces and types
-- **network_system** (Tier 4) - TCP/QUIC server implementation
+- **network_system** (Tier 4) - TCP server implementation
 - **container_system** (Tier 1) - Protocol serialization (required for query protocol messages)
 
 ### Optional
@@ -308,6 +308,15 @@ rate_limit.block_duration_ms=60000
   - [x] Performance benchmarks (target: 10k+ queries/sec)
   - [x] Latency measurement (target: < 1ms routing overhead)
 - [ ] (Optional) Implement Query Result Cache
+
+## Planned Features
+
+The following features are planned for future releases:
+
+| Feature | Description | Status |
+|---------|-------------|--------|
+| QUIC Protocol | High-performance UDP-based transport with built-in TLS | Planned |
+| Query Result Cache | In-memory cache for SELECT query results with TTL and LRU eviction | Planned (see [#30](https://github.com/kcenon/database_server/issues/30)) |
 
 ## Security
 


### PR DESCRIPTION
## Summary

- Update architecture diagram to show TCP only (remove QUIC reference)
- Update network_system dependency description from TCP/QUIC to TCP
- Add Planned Features section documenting QUIC and Query Cache as future work
- Fix CMakeLists.txt comments to reflect TCP-only implementation

## Changes

| File | Change |
|------|--------|
| README.md | Updated architecture diagram, dependencies section, added Planned Features |
| CMakeLists.txt | Fixed QUIC references in comments |

## Test plan

- [x] Build succeeds with no errors
- [x] No missing headers detected
- [x] All documentation accurately reflects current implementation state

Closes #28