### PR TITLE
refactor(gateway): adopt Result<T> pattern for error handling

### DIFF
--- a/include/kcenon/database_server/gateway/query_router.h
+++ b/include/kcenon/database_server/gateway/query_router.h
@@ -169,12 +169,12 @@ public:
 	/**
 	 * @brief Execute a query request
 	 * @param request The query request to execute
-	 * @return Query response with results or error
+	 * @return Result containing query response or error
 	 *
 	 * This is the main entry point for query execution.
 	 * Handles all query types and returns appropriate response.
 	 */
-	[[nodiscard]] query_response execute(const query_request& request);
+	[[nodiscard]] kcenon::common::Result<query_response> execute(const query_request& request);
 
 	/**
 	 * @brief Execute a query request asynchronously

--- a/include/kcenon/database_server/server_app.h
+++ b/include/kcenon/database_server/server_app.h
@@ -59,6 +59,7 @@
 
 // Common system interfaces
 #include <kcenon/common/interfaces/executor_interface.h>
+#include <kcenon/common/patterns/result.h>
 
 // Forward declarations
 namespace database_server::gateway
@@ -133,7 +134,7 @@ public:
 	/**
 	 * @brief Initialize the server with configuration
 	 * @param config_path Path to the configuration file (YAML)
-	 * @return true if initialization succeeded, false otherwise
+	 * @return Result indicating success or error with message
 	 *
 	 * This method:
 	 * - Loads and validates the configuration file
@@ -141,14 +142,14 @@ public:
 	 * - Sets up signal handlers
 	 * - Prepares network listeners (but does not start them)
 	 */
-	bool initialize(const std::string& config_path);
+	[[nodiscard]] kcenon::common::VoidResult initialize(const std::string& config_path);
 
 	/**
 	 * @brief Initialize the server with a configuration object
 	 * @param config Server configuration
-	 * @return true if initialization succeeded, false otherwise
+	 * @return Result indicating success or error with message
 	 */
-	bool initialize(const server_config& config);
+	[[nodiscard]] kcenon::common::VoidResult initialize(const server_config& config);
 
 	/**
 	 * @brief Run the server main loop

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -121,9 +121,10 @@ int main(int argc, char* argv[])
 		config = database_server::server_config::default_config();
 	}
 
-	if (!app.initialize(config))
+	auto init_result = app.initialize(config);
+	if (init_result.is_err())
 	{
-		std::cerr << "Failed to initialize server\n";
+		std::cerr << "Failed to initialize server: " << init_result.error().message << "\n";
 		return 1;
 	}
 


### PR DESCRIPTION
## Summary

Closes #46

This PR migrates the gateway module to use the `Result<T>` pattern from `common_system` for consistent error handling.

### Changes

- **query_cache**
  - `get()` now returns `Result<query_response>` instead of `std::optional`
  - `put()`, `invalidate()`, `invalidate_key()` now return `VoidResult`
  
- **query_router**
  - `execute()` now returns `Result<query_response>` instead of returning `query_response` directly
  
- **server_app**
  - `initialize()` now returns `VoidResult` instead of `bool`

### Error Codes

Uses error codes from `kcenon::common::error_codes`:
- `NOT_INITIALIZED` - for cache disabled / no connection pool
- `NOT_FOUND` - for cache misses
- `INVALID_ARGUMENT` - for invalid input parameters
- `INTERNAL_ERROR` - for execution errors
- `ALREADY_EXISTS` - for server already initialized

### Test Updates

- Updated `query_cache_test.cpp` to use `is_ok()`/`is_err()` methods
- Updated `integration_test.cpp` to handle `Result<T>` returns
- All 249 tests pass

## Test Plan

- [x] Build passes with no errors
- [x] All 249 unit tests pass
- [x] Integration tests pass