### PR TITLE
refactor(core): integrate logger into server_app for structured logging

### DIFF
--- a/include/kcenon/database_server/server_app.h
+++ b/include/kcenon/database_server/server_app.h
@@ -59,6 +59,7 @@
 
 // Common system interfaces
 #include <kcenon/common/interfaces/executor_interface.h>
+#include <kcenon/common/interfaces/logger_interface.h>
 #include <kcenon/common/patterns/result.h>
 
 // Forward declarations
@@ -202,6 +203,21 @@ public:
 	 */
 	void set_executor(std::shared_ptr<kcenon::common::interfaces::IExecutor> executor);
 
+	/**
+	 * @brief Get the logger used by this server
+	 * @return Shared pointer to logger, or nullptr if not set
+	 */
+	std::shared_ptr<kcenon::common::interfaces::ILogger> get_logger() const;
+
+	/**
+	 * @brief Set the logger for this server
+	 * @param logger Shared pointer to logger
+	 *
+	 * When set, replaces stdout/stderr logging with structured logging.
+	 * If not set, a default console logger is created during initialization.
+	 */
+	void set_logger(std::shared_ptr<kcenon::common::interfaces::ILogger> logger);
+
 private:
 	/**
 	 * @brief Setup signal handlers for graceful shutdown
@@ -231,6 +247,9 @@ private:
 
 	// Executor for background tasks
 	std::shared_ptr<kcenon::common::interfaces::IExecutor> executor_;
+
+	// Logger for structured logging
+	std::shared_ptr<kcenon::common::interfaces::ILogger> logger_;
 
 	// Signal handling
 	static server_app* instance_;


### PR DESCRIPTION
Closes #62

## Summary
- Integrate ILogger interface into server_app replacing std::cout/std::cerr
- Add get_logger() and set_logger() methods for logger injection
- Create default console_logger if no custom logger is provided
- Use appropriate log levels (info, warning, error) throughout server lifecycle

## Test Plan
- [x] All 249 tests pass
- [x] Build succeeds without errors
- [x] Verified logger output format with console_logger