### PR TITLE
refactor(build): migrate to KCENON_WITH_*=1 unified macro system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,9 +386,9 @@ endfunction()
 # Add common_system include (header-only library, no linking needed)
 if(common_system_INCLUDE_DIR)
     target_include_directories(DatabaseServerLib PUBLIC ${common_system_INCLUDE_DIR})
-    # Define WITH_COMMON_SYSTEM for feature_flags.h (maps to KCENON_WITH_COMMON_SYSTEM)
+    # Define KCENON_WITH_COMMON_SYSTEM=1 for unified macro system
     # This ensures VoidResult type matches between network_system and database_server
-    target_compile_definitions(DatabaseServerLib PUBLIC WITH_COMMON_SYSTEM)
+    target_compile_definitions(DatabaseServerLib PUBLIC KCENON_WITH_COMMON_SYSTEM=1)
 endif()
 # common_system is header-only, so no library linking is needed
 
@@ -494,8 +494,8 @@ endif()
 
 # Optional: monitoring_system
 if(BUILD_WITH_MONITORING_SYSTEM)
-    # Define WITH_MONITORING_SYSTEM for feature_flags.h (maps to KCENON_WITH_MONITORING_SYSTEM)
-    target_compile_definitions(DatabaseServerLib PUBLIC WITH_MONITORING_SYSTEM)
+    # Define KCENON_WITH_MONITORING_SYSTEM=1 for unified macro system
+    target_compile_definitions(DatabaseServerLib PUBLIC KCENON_WITH_MONITORING_SYSTEM=1)
     if(monitoring_system_INCLUDE_DIR)
         target_include_directories(DatabaseServerLib PUBLIC ${monitoring_system_INCLUDE_DIR})
     endif()
@@ -505,8 +505,8 @@ if(BUILD_WITH_MONITORING_SYSTEM)
 endif()
 
 # container_system (REQUIRED for protocol serialization)
-# Define WITH_CONTAINER_SYSTEM for feature_flags.h (maps to KCENON_WITH_CONTAINER_SYSTEM)
-target_compile_definitions(DatabaseServerLib PUBLIC WITH_CONTAINER_SYSTEM)
+# Define KCENON_WITH_CONTAINER_SYSTEM=1 for unified macro system
+target_compile_definitions(DatabaseServerLib PUBLIC KCENON_WITH_CONTAINER_SYSTEM=1)
 if(container_system_INCLUDE_DIR)
     target_include_directories(DatabaseServerLib PUBLIC ${container_system_INCLUDE_DIR})
     # Also add the root directory for headers in container_system/core/

--- a/README.md
+++ b/README.md
@@ -96,15 +96,15 @@ cmake --build .
 
 ### Integration Macros
 
-Source code uses `KCENON_WITH_*` macros (from `<kcenon/common/config/feature_flags.h>`) for integration gating:
+Source code uses unified `KCENON_WITH_*=1` macros for integration gating, ensuring consistency across all kcenon ecosystem projects:
 
-| Macro | Preprocessor Symbol | CMake Option | Description |
-|-------|---------------------|--------------|-------------|
-| `KCENON_WITH_CONTAINER_SYSTEM` | `WITH_CONTAINER_SYSTEM` | `BUILD_WITH_CONTAINER_SYSTEM` | Container serialization support |
-| `KCENON_WITH_MONITORING_SYSTEM` | `WITH_MONITORING_SYSTEM` | `BUILD_WITH_MONITORING_SYSTEM` | Monitoring integration |
-| `KCENON_WITH_COMMON_SYSTEM` | `WITH_COMMON_SYSTEM` | Auto-detected | Common system integration |
+| Macro | CMake Option | Description |
+|-------|--------------|-------------|
+| `KCENON_WITH_CONTAINER_SYSTEM=1` | `BUILD_WITH_CONTAINER_SYSTEM` | Container serialization support |
+| `KCENON_WITH_MONITORING_SYSTEM=1` | `BUILD_WITH_MONITORING_SYSTEM` | Monitoring integration |
+| `KCENON_WITH_COMMON_SYSTEM=1` | Auto-detected | Common system integration |
 
-When CMake options like `BUILD_WITH_CONTAINER_SYSTEM` are enabled, CMake defines `WITH_*` preprocessor symbols (e.g., `WITH_CONTAINER_SYSTEM`). The `feature_flags.h` header from `common_system` then maps these to `KCENON_WITH_*` macros for consistent integration gating across repositories.
+CMake directly defines `KCENON_WITH_*=1` preprocessor macros when the corresponding `BUILD_WITH_*` options are enabled. This unified macro system ensures consistent integration gating across all kcenon repositories without intermediate mapping.
 
 ### Running Tests
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,8 +39,8 @@ endif()
 
 # Link container_system if available
 if(BUILD_WITH_CONTAINER_SYSTEM)
-    # Define both BUILD_WITH_* (legacy) and WITH_* (feature_flags.h)
-    target_compile_definitions(GatewayLib PUBLIC BUILD_WITH_CONTAINER_SYSTEM WITH_CONTAINER_SYSTEM)
+    # Define KCENON_WITH_CONTAINER_SYSTEM=1 for unified macro system
+    target_compile_definitions(GatewayLib PUBLIC KCENON_WITH_CONTAINER_SYSTEM=1)
     # Try different include paths for container_system
     if(container_system_INCLUDE_DIR)
         target_include_directories(GatewayLib PUBLIC ${container_system_INCLUDE_DIR})


### PR DESCRIPTION
## Summary

- Replace legacy `WITH_*` preprocessor symbols with unified `KCENON_WITH_*=1` macros
- Update CMakeLists.txt, tests/CMakeLists.txt compile definitions
- Update README.md documentation to reflect the new macro system

## Why

1. **Ecosystem Consistency**: Aligns with other kcenon projects (file_trans_system, messaging_system)
2. **Avoid Conflicts**: Legacy `WITH_*` macros may conflict with third-party libraries
3. **Simplified Configuration**: Direct `KCENON_WITH_*=1` definitions without intermediate mapping

## Test Plan

- [x] CMake configuration succeeds with updated macros
- [x] Full build completes without errors
- [x] All 249 unit tests pass (100%)
- [x] No regression in existing functionality

Closes #65