### PR TITLE
refactor(build): update CMake dependency detection for restructured upstream headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -470,7 +470,7 @@ endif()
 ##################################################
 
 # 1. Link network_system first (it depends on thread_system)
-link_system_dependency(DatabaseServerLib NETWORK_SYSTEM NetworkSystem network_system messaging_system network)
+link_system_dependency(DatabaseServerLib NETWORK_SYSTEM NetworkSystem network_system network)
 
 # 2. Link database_system
 link_system_dependency(DatabaseServerLib DATABASE_SYSTEM DatabaseSystem database_system database)


### PR DESCRIPTION
Closes #70

## Summary
- Remove deprecated `messaging_system` library fallback from network_system link targets
- Verified all `KCENON_WITH_*` and `KCENON_HAS_*` compile definitions are current
- Verified `FindSystemDependency.cmake` target lists match current upstream library names
- Verified header probe paths (`log_collector.h`, `database_backend.h`) are correct
- Verified container_system include path logic works with current layout

## Audit Results

| Item | Status |
|------|--------|
| `messaging_system` references | Removed (deprecated) |
| Other deprecated library fallbacks | None found |
| `KCENON_WITH_COMMON_SYSTEM=1` | Correct |
| `KCENON_HAS_COMMON_SYSTEM=1` | Correct (container_system Result API) |
| `KCENON_WITH_CONTAINER_SYSTEM=1` | Correct |
| `KCENON_WITH_MONITORING_SYSTEM=1` | Correct (optional) |
| Logger header probe | Correct (`kcenon/logger/core/log_collector.h`) |
| FindSystemDependency targets | All current |
| Container include path logic | Working correctly |
| C++20 module files | No deprecated patterns |

## Test Plan
- [x] CMake configuration succeeds locally (macOS)
- [x] Build completes with correct link order (30/30 targets)
- [x] All 249 tests pass
- [x] CI passes on all platforms (Ubuntu GCC, Ubuntu Clang, macOS Clang, Windows MSVC)