### PR TITLE
refactor(gateway): centralize container_system includes for namespace migration

### DIFF
--- a/include/kcenon/database_server/gateway/container_compat.h
+++ b/include/kcenon/database_server/gateway/container_compat.h
@@ -1,0 +1,30 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file container_compat.h
+ * @brief Compatibility header for container_system includes
+ *
+ * Centralizes all container_system include paths to prepare for the
+ * upcoming namespace migration from container_module to kcenon::container.
+ *
+ * Migration timeline (container_system #364):
+ * - v1.x (current): Legacy paths (<container.h>, container_module::)
+ * - v2.0: Deprecated aliases added
+ * - v3.0: Legacy paths removed — only this file needs updating
+ *
+ * When v3.0 lands, update the include path and forward declaration below.
+ */
+
+#pragma once
+
+#if KCENON_WITH_CONTAINER_SYSTEM
+
+#if __has_include(<kcenon/container/container.h>)
+#include <kcenon/container/container.h>
+#else
+#include <container.h>
+#endif
+
+#endif // KCENON_WITH_CONTAINER_SYSTEM

--- a/include/kcenon/database_server/gateway/query_protocol.h
+++ b/include/kcenon/database_server/gateway/query_protocol.h
@@ -60,6 +60,7 @@
 #include <kcenon/common/patterns/result.h>
 
 // Forward declaration for container_system
+// When migrating to kcenon::container namespace, update this and container_compat.h
 namespace container_module
 {
 class value_container;

--- a/src/gateway/gateway_server.cpp
+++ b/src/gateway/gateway_server.cpp
@@ -37,9 +37,7 @@
 
 #include <kcenon/common/config/feature_flags.h>
 
-#if KCENON_WITH_CONTAINER_SYSTEM
-#include <container.h>
-#endif
+#include <kcenon/database_server/gateway/container_compat.h>
 
 #include <chrono>
 

--- a/src/gateway/protocol/serialization_helpers.h
+++ b/src/gateway/protocol/serialization_helpers.h
@@ -43,9 +43,7 @@
 #include <kcenon/common/patterns/result.h>
 #include <kcenon/database_server/gateway/query_protocol.h>
 
-#if KCENON_WITH_CONTAINER_SYSTEM
-#include <container.h>
-#endif
+#include <kcenon/database_server/gateway/container_compat.h>
 
 #include <chrono>
 #include <cstdint>


### PR DESCRIPTION
Closes #73

## Summary

- Created `container_compat.h` compatibility header with `__has_include` fallback for the upcoming `container_module` → `kcenon::container` namespace migration
- Replaced direct `#include <container.h>` in `gateway_server.cpp` and `serialization_helpers.h` with the centralized wrapper
- Added migration reference comment to `query_protocol.h` forward declaration

## Motivation

container_system announced a multi-version namespace migration (#364):
- **v1.x** (current): Legacy paths work
- **v2.0**: Deprecated aliases
- **v3.0**: Legacy paths removed (**breaking**)

This change ensures that when v3.0 lands, only `container_compat.h` needs updating instead of modifying every file.

## Changes

| File | Change |
|------|--------|
| `container_compat.h` (NEW) | Compatibility header with `__has_include` fallback |
| `gateway_server.cpp` | Replace `#include <container.h>` with compat header |
| `serialization_helpers.h` | Replace `#include <container.h>` with compat header |
| `query_protocol.h` | Add migration reference comment |

## Test Plan

- [x] Full project builds successfully (32/32 targets)
- [x] All 249 tests pass (including query protocol, integration, gateway benchmarks)
- [x] `__has_include` correctly falls back to legacy path on current container_system v1.x
- [ ] CI: All workflows pass