### PR TITLE
feat(infra): add upstream dependency version pinning for kcenon ecosystem

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -45,11 +45,21 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Load dependency versions
+      id: deps
+      shell: bash
+      run: |
+        for dep in common_system thread_system logger_system database_system network_system container_system; do
+          sha=$(jq -r ".\"$dep\".commit" deps/kcenon-versions.json)
+          echo "${dep}_ref=$sha" >> $GITHUB_OUTPUT
+        done
+
     - name: Checkout common_system
       uses: actions/checkout@v4
       with:
         repository: kcenon/common_system
         path: common_system
+        ref: ${{ steps.deps.outputs.common_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout thread_system
@@ -57,6 +67,7 @@ jobs:
       with:
         repository: kcenon/thread_system
         path: thread_system
+        ref: ${{ steps.deps.outputs.thread_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout logger_system
@@ -64,6 +75,7 @@ jobs:
       with:
         repository: kcenon/logger_system
         path: logger_system
+        ref: ${{ steps.deps.outputs.logger_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout database_system
@@ -71,6 +83,7 @@ jobs:
       with:
         repository: kcenon/database_system
         path: database_system
+        ref: ${{ steps.deps.outputs.database_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout network_system
@@ -78,6 +91,7 @@ jobs:
       with:
         repository: kcenon/network_system
         path: network_system
+        ref: ${{ steps.deps.outputs.network_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout container_system
@@ -85,6 +99,7 @@ jobs:
       with:
         repository: kcenon/container_system
         path: container_system
+        ref: ${{ steps.deps.outputs.container_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install dependencies (Ubuntu)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,21 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Load dependency versions
+      id: deps
+      shell: bash
+      run: |
+        for dep in common_system thread_system logger_system monitoring_system database_system network_system container_system; do
+          sha=$(jq -r ".\"$dep\".commit" deps/kcenon-versions.json)
+          echo "${dep}_ref=$sha" >> $GITHUB_OUTPUT
+        done
+
     - name: Checkout common_system
       uses: actions/checkout@v4
       with:
         repository: kcenon/common_system
         path: common_system
+        ref: ${{ steps.deps.outputs.common_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout thread_system
@@ -54,6 +64,7 @@ jobs:
       with:
         repository: kcenon/thread_system
         path: thread_system
+        ref: ${{ steps.deps.outputs.thread_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout logger_system
@@ -61,6 +72,7 @@ jobs:
       with:
         repository: kcenon/logger_system
         path: logger_system
+        ref: ${{ steps.deps.outputs.logger_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout monitoring_system
@@ -68,6 +80,7 @@ jobs:
       with:
         repository: kcenon/monitoring_system
         path: monitoring_system
+        ref: ${{ steps.deps.outputs.monitoring_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout database_system
@@ -75,6 +88,7 @@ jobs:
       with:
         repository: kcenon/database_system
         path: database_system
+        ref: ${{ steps.deps.outputs.database_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout network_system
@@ -82,6 +96,7 @@ jobs:
       with:
         repository: kcenon/network_system
         path: network_system
+        ref: ${{ steps.deps.outputs.network_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout container_system
@@ -89,6 +104,7 @@ jobs:
       with:
         repository: kcenon/container_system
         path: container_system
+        ref: ${{ steps.deps.outputs.container_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install dependencies (Ubuntu)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,11 +17,21 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Load dependency versions
+      id: deps
+      shell: bash
+      run: |
+        for dep in common_system thread_system logger_system database_system network_system container_system; do
+          sha=$(jq -r ".\"$dep\".commit" deps/kcenon-versions.json)
+          echo "${dep}_ref=$sha" >> $GITHUB_OUTPUT
+        done
+
     - name: Checkout common_system
       uses: actions/checkout@v4
       with:
         repository: kcenon/common_system
         path: common_system
+        ref: ${{ steps.deps.outputs.common_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout thread_system
@@ -29,6 +39,7 @@ jobs:
       with:
         repository: kcenon/thread_system
         path: thread_system
+        ref: ${{ steps.deps.outputs.thread_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout logger_system
@@ -36,6 +47,7 @@ jobs:
       with:
         repository: kcenon/logger_system
         path: logger_system
+        ref: ${{ steps.deps.outputs.logger_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout database_system
@@ -43,6 +55,7 @@ jobs:
       with:
         repository: kcenon/database_system
         path: database_system
+        ref: ${{ steps.deps.outputs.database_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout network_system
@@ -50,6 +63,7 @@ jobs:
       with:
         repository: kcenon/network_system
         path: network_system
+        ref: ${{ steps.deps.outputs.network_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout container_system
@@ -57,6 +71,7 @@ jobs:
       with:
         repository: kcenon/container_system
         path: container_system
+        ref: ${{ steps.deps.outputs.container_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install dependencies

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -30,11 +30,21 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Load dependency versions
+      id: deps
+      shell: bash
+      run: |
+        for dep in common_system thread_system logger_system database_system network_system container_system; do
+          sha=$(jq -r ".\"$dep\".commit" deps/kcenon-versions.json)
+          echo "${dep}_ref=$sha" >> $GITHUB_OUTPUT
+        done
+
     - name: Checkout common_system
       uses: actions/checkout@v4
       with:
         repository: kcenon/common_system
         path: common_system
+        ref: ${{ steps.deps.outputs.common_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout thread_system
@@ -42,6 +52,7 @@ jobs:
       with:
         repository: kcenon/thread_system
         path: thread_system
+        ref: ${{ steps.deps.outputs.thread_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout logger_system
@@ -49,6 +60,7 @@ jobs:
       with:
         repository: kcenon/logger_system
         path: logger_system
+        ref: ${{ steps.deps.outputs.logger_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout database_system
@@ -56,6 +68,7 @@ jobs:
       with:
         repository: kcenon/database_system
         path: database_system
+        ref: ${{ steps.deps.outputs.database_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout network_system
@@ -63,6 +76,7 @@ jobs:
       with:
         repository: kcenon/network_system
         path: network_system
+        ref: ${{ steps.deps.outputs.network_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout container_system
@@ -70,6 +84,7 @@ jobs:
       with:
         repository: kcenon/container_system
         path: container_system
+        ref: ${{ steps.deps.outputs.container_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install dependencies (Ubuntu)

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -26,11 +26,21 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Load dependency versions
+      id: deps
+      shell: bash
+      run: |
+        for dep in common_system thread_system logger_system database_system network_system container_system; do
+          sha=$(jq -r ".\"$dep\".commit" deps/kcenon-versions.json)
+          echo "${dep}_ref=$sha" >> $GITHUB_OUTPUT
+        done
+
     - name: Checkout common_system
       uses: actions/checkout@v4
       with:
         repository: kcenon/common_system
         path: common_system
+        ref: ${{ steps.deps.outputs.common_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout thread_system
@@ -38,6 +48,7 @@ jobs:
       with:
         repository: kcenon/thread_system
         path: thread_system
+        ref: ${{ steps.deps.outputs.thread_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout logger_system
@@ -45,6 +56,7 @@ jobs:
       with:
         repository: kcenon/logger_system
         path: logger_system
+        ref: ${{ steps.deps.outputs.logger_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout database_system
@@ -52,6 +64,7 @@ jobs:
       with:
         repository: kcenon/database_system
         path: database_system
+        ref: ${{ steps.deps.outputs.database_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout network_system
@@ -59,6 +72,7 @@ jobs:
       with:
         repository: kcenon/network_system
         path: network_system
+        ref: ${{ steps.deps.outputs.network_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout container_system
@@ -66,6 +80,7 @@ jobs:
       with:
         repository: kcenon/container_system
         path: container_system
+        ref: ${{ steps.deps.outputs.container_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install dependencies

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -17,11 +17,21 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Load dependency versions
+      id: deps
+      shell: bash
+      run: |
+        for dep in common_system thread_system logger_system database_system network_system container_system; do
+          sha=$(jq -r ".\"$dep\".commit" deps/kcenon-versions.json)
+          echo "${dep}_ref=$sha" >> $GITHUB_OUTPUT
+        done
+
     - name: Checkout common_system
       uses: actions/checkout@v4
       with:
         repository: kcenon/common_system
         path: common_system
+        ref: ${{ steps.deps.outputs.common_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout thread_system
@@ -29,6 +39,7 @@ jobs:
       with:
         repository: kcenon/thread_system
         path: thread_system
+        ref: ${{ steps.deps.outputs.thread_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout logger_system
@@ -36,6 +47,7 @@ jobs:
       with:
         repository: kcenon/logger_system
         path: logger_system
+        ref: ${{ steps.deps.outputs.logger_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout database_system
@@ -43,6 +55,7 @@ jobs:
       with:
         repository: kcenon/database_system
         path: database_system
+        ref: ${{ steps.deps.outputs.database_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout network_system
@@ -50,6 +63,7 @@ jobs:
       with:
         repository: kcenon/network_system
         path: network_system
+        ref: ${{ steps.deps.outputs.network_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout container_system
@@ -57,6 +71,7 @@ jobs:
       with:
         repository: kcenon/container_system
         path: container_system
+        ref: ${{ steps.deps.outputs.container_system_ref }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install dependencies

--- a/deps/kcenon-versions.json
+++ b/deps/kcenon-versions.json
@@ -1,0 +1,39 @@
+{
+  "_comment": "Pinned dependency versions for kcenon ecosystem. Update with: scripts/update-deps.sh",
+  "_updated": "2026-02-12",
+  "common_system": {
+    "repo": "kcenon/common_system",
+    "commit": "07408eea603fdb40d79283362a2fd3ed72456e80",
+    "verified_date": "2026-02-12"
+  },
+  "thread_system": {
+    "repo": "kcenon/thread_system",
+    "commit": "c974afe9a4631d782f5f9161f29b3c2e0987740a",
+    "verified_date": "2026-02-12"
+  },
+  "logger_system": {
+    "repo": "kcenon/logger_system",
+    "commit": "5033256594b428d27640df1cb92f9d1dd2eb7dbf",
+    "verified_date": "2026-02-12"
+  },
+  "monitoring_system": {
+    "repo": "kcenon/monitoring_system",
+    "commit": "65a3d6fcf7908cf0a6465dbe5d6f0ef680ac2f7f",
+    "verified_date": "2026-02-12"
+  },
+  "database_system": {
+    "repo": "kcenon/database_system",
+    "commit": "49cb644f83a8b6835756ae4bc2f923a070070280",
+    "verified_date": "2026-02-12"
+  },
+  "network_system": {
+    "repo": "kcenon/network_system",
+    "commit": "1876675d7c878181b5de13b11df9a2fbf51da37d",
+    "verified_date": "2026-02-12"
+  },
+  "container_system": {
+    "repo": "kcenon/container_system",
+    "commit": "4bbf1023dfac44e8f2061152925d6204b2a34878",
+    "verified_date": "2026-02-12"
+  }
+}

--- a/scripts/update-deps.sh
+++ b/scripts/update-deps.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Update dependency versions in deps/kcenon-versions.json
+#
+# Usage:
+#   ./scripts/update-deps.sh                    # Update all deps from sibling directories
+#   ./scripts/update-deps.sh --check            # Show current vs latest without updating
+#   ./scripts/update-deps.sh --dep thread_system # Update only thread_system
+#
+# Prerequisites:
+#   - jq installed
+#   - Dependencies cloned as sibling directories (../common_system, etc.)
+#     OR use --remote to fetch latest from GitHub
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+VERSIONS_FILE="$PROJECT_ROOT/deps/kcenon-versions.json"
+
+DEPS=(common_system thread_system logger_system monitoring_system database_system network_system container_system)
+
+CHECK_ONLY=false
+SINGLE_DEP=""
+USE_REMOTE=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --check) CHECK_ONLY=true; shift ;;
+        --dep) SINGLE_DEP="$2"; shift 2 ;;
+        --remote) USE_REMOTE=true; shift ;;
+        -h|--help)
+            echo "Usage: $0 [--check] [--dep <name>] [--remote]"
+            echo ""
+            echo "Options:"
+            echo "  --check   Show current vs latest without updating"
+            echo "  --dep     Update only the specified dependency"
+            echo "  --remote  Fetch latest SHA from GitHub (requires gh CLI)"
+            exit 0
+            ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+if ! command -v jq &>/dev/null; then
+    echo "Error: jq is required. Install with: brew install jq / apt install jq"
+    exit 1
+fi
+
+if [ ! -f "$VERSIONS_FILE" ]; then
+    echo "Error: $VERSIONS_FILE not found"
+    exit 1
+fi
+
+get_local_sha() {
+    local dep="$1"
+    local dep_dir="$PROJECT_ROOT/../$dep"
+    if [ -d "$dep_dir/.git" ]; then
+        git -C "$dep_dir" rev-parse HEAD
+    else
+        echo ""
+    fi
+}
+
+get_remote_sha() {
+    local dep="$1"
+    if command -v gh &>/dev/null; then
+        gh api "repos/kcenon/$dep/commits/main" --jq '.sha' 2>/dev/null || echo ""
+    else
+        echo ""
+    fi
+}
+
+get_pinned_sha() {
+    local dep="$1"
+    jq -r ".\"$dep\".commit" "$VERSIONS_FILE"
+}
+
+TODAY=$(date +%Y-%m-%d)
+UPDATED=0
+
+for dep in "${DEPS[@]}"; do
+    if [ -n "$SINGLE_DEP" ] && [ "$dep" != "$SINGLE_DEP" ]; then
+        continue
+    fi
+
+    pinned=$(get_pinned_sha "$dep")
+
+    if [ "$USE_REMOTE" = true ]; then
+        latest=$(get_remote_sha "$dep")
+        source_label="remote"
+    else
+        latest=$(get_local_sha "$dep")
+        source_label="local"
+    fi
+
+    if [ -z "$latest" ]; then
+        echo "  SKIP  $dep — not found ($source_label)"
+        continue
+    fi
+
+    short_pinned="${pinned:0:10}"
+    short_latest="${latest:0:10}"
+
+    if [ "$pinned" = "$latest" ]; then
+        echo "  OK    $dep — $short_pinned (up to date)"
+    elif [ "$CHECK_ONLY" = true ]; then
+        echo "  STALE $dep — pinned: $short_pinned, $source_label: $short_latest"
+    else
+        # Update the JSON file
+        tmp=$(mktemp)
+        jq --arg dep "$dep" --arg sha "$latest" --arg date "$TODAY" \
+            '.[$dep].commit = $sha | .[$dep].verified_date = $date' \
+            "$VERSIONS_FILE" > "$tmp"
+        mv "$tmp" "$VERSIONS_FILE"
+        echo "  UPDATE $dep — $short_pinned -> $short_latest"
+        UPDATED=$((UPDATED + 1))
+    fi
+done
+
+if [ "$CHECK_ONLY" = true ]; then
+    echo ""
+    echo "Run without --check to apply updates."
+elif [ "$UPDATED" -gt 0 ]; then
+    # Update the top-level _updated field
+    tmp=$(mktemp)
+    jq --arg date "$TODAY" '._updated = $date' "$VERSIONS_FILE" > "$tmp"
+    mv "$tmp" "$VERSIONS_FILE"
+    echo ""
+    echo "Updated $UPDATED dependencies. Review with: git diff deps/kcenon-versions.json"
+else
+    echo ""
+    echo "All dependencies are up to date."
+fi


### PR DESCRIPTION
Closes #74

## Summary

- Created `deps/kcenon-versions.json` as single source of truth for all 7 kcenon ecosystem dependency versions
- Updated all 6 CI workflows to checkout pinned commit SHAs instead of HEAD
- Added `scripts/update-deps.sh` helper script for managing dependency updates

## Motivation

All kcenon ecosystem dependencies are pre-1.0 with no tagged releases. Tracking HEAD means any upstream commit can break the build. This has already happened with network_system header reorganization and database_system deprecated type removal.

## Architecture

```
deps/kcenon-versions.json  ← Single source of truth (commit SHAs)
         ↓
CI Workflows (6 files)     ← "Load dependency versions" step reads JSON
         ↓
actions/checkout ref:      ← Pinned checkout instead of HEAD
```

### Version Manifest (`deps/kcenon-versions.json`)

| Dependency | Pinned Commit | Verified Date |
|-----------|---------------|---------------|
| common_system | `07408eea60` | 2026-02-12 |
| thread_system | `c974afe9a4` | 2026-02-12 |
| logger_system | `5033256594` | 2026-02-12 |
| monitoring_system | `65a3d6fcf7` | 2026-02-12 |
| database_system | `49cb644f83` | 2026-02-12 |
| network_system | `1876675d7c` | 2026-02-12 |
| container_system | `4bbf1023df` | 2026-02-12 |

### Update Process

```bash
# Check for stale versions
./scripts/update-deps.sh --check

# Update all dependencies to local HEAD
./scripts/update-deps.sh

# Update from GitHub remote
./scripts/update-deps.sh --remote

# Update single dependency
./scripts/update-deps.sh --dep thread_system
```

## Files Changed

| File | Change |
|------|--------|
| `deps/kcenon-versions.json` (NEW) | Version manifest with 7 pinned dependencies |
| `scripts/update-deps.sh` (NEW) | Dependency update helper script |
| `.github/workflows/ci.yml` | Add version loading + pinned checkout |
| `.github/workflows/integration-tests.yml` | Add version loading + pinned checkout |
| `.github/workflows/coverage.yml` | Add version loading + pinned checkout |
| `.github/workflows/sanitizers.yml` | Add version loading + pinned checkout |
| `.github/workflows/static-analysis.yml` | Add version loading + pinned checkout |
| `.github/workflows/benchmarks.yml` | Add version loading + pinned checkout |

## Test Plan

- [x] Local build succeeds (32/32 targets)
- [x] All 249 tests pass
- [x] `scripts/update-deps.sh --check` correctly reports version status
- [x] CI: All 6 workflows pass with pinned versions
- [x] Verify `jq` availability on all CI runner platforms (Ubuntu, macOS, Windows)