### PR TITLE
docs(server): create Korean README and architecture documentation

### DIFF
--- a/README.kr.md
+++ b/README.kr.md
@@ -1,0 +1,610 @@
+> 🇺🇸 [English Version](README.md)
+
+# Database Server
+
+클라이언트 애플리케이션과 물리적 데이터베이스 사이에서 커넥션 풀링, 쿼리 라우팅, 캐싱 기능을 제공하는 고성능 데이터베이스 게이트웨이 미들웨어 서버입니다.
+
+## 개요
+
+Database Server는 kcenon 통합 시스템 아키텍처에서 모놀리식 라이브러리를 게이트웨이 미들웨어 아키텍처로 전환하는 과정의 일부입니다. 클라이언트 애플리케이션과 물리적 데이터베이스 사이에 위치하여 다음 기능을 제공합니다:
+
+- **커넥션 풀링**: 우선순위 기반 스케줄링을 통한 효율적인 커넥션 관리
+- **쿼리 라우팅**: 다수의 데이터베이스 커넥션에 대한 로드 밸런싱
+- **헬스 모니터링**: 장애 커넥션의 자동 감지 및 복구
+- **쿼리 캐싱** (선택): 자주 실행되는 쿼리 결과 캐싱
+
+## 아키텍처
+
+```
+┌─────────────────────────────────────────────────┐
+│                database_server                   │
+├─────────────────────────────────────────────────┤
+│  ┌─────────────┐    ┌─────────────────────┐    │
+│  │   Listener   │───▶│  Auth Middleware    │    │
+│  │    (TCP)    │    │  (Rate Limiting)    │    │
+│  └─────────────┘    └─────────┬───────────┘    │
+│                               │                 │
+│                    ┌──────────▼──────────┐     │
+│                    │   Request Handler   │     │
+│                    └──────────┬──────────┘     │
+│                               │                 │
+│                    ┌──────────▼──────────┐     │
+│                    │   Query Router      │     │
+│                    │   (Load Balancer)   │     │
+│                    └──────────┬──────────┘     │
+│                               │                 │
+│  ┌─────────────┐    ┌────────▼────────┐       │
+│  │ Query Cache │◀──▶│ Connection Pool │       │
+│  │  (Optional) │    │                 │       │
+│  └─────────────┘    └────────┬────────┘       │
+│                               │                 │
+└───────────────────────────────┼─────────────────┘
+                                │
+                    ┌───────────▼───────────┐
+                    │   Physical Database    │
+                    │ (PostgreSQL, MySQL...) │
+                    └───────────────────────┘
+```
+
+## 의존성
+
+### 필수
+
+- **common_system** (Tier 0) - 핵심 유틸리티, Result<T>, 로깅 인터페이스
+- **thread_system** (Tier 1) - 작업 스케줄링, 스레드 풀 관리
+- **database_system** (Tier 2) - 데이터베이스 인터페이스 및 타입
+- **network_system** (Tier 4) - TCP 서버 구현
+- **container_system** (Tier 1) - 프로토콜 직렬화 (쿼리 프로토콜 메시지에 필요)
+
+### 선택
+
+- **monitoring_system** (Tier 3) - 성능 메트릭 및 헬스 모니터링
+
+## 빌드
+
+### 사전 요구사항
+
+- CMake 3.16 이상
+- C++20 호환 컴파일러 (GCC 10+, Clang 12+, MSVC 2019+)
+- 필수 시스템 의존성이 빌드되어 사용 가능한 상태
+
+### 빌드 단계
+
+```bash
+# 빌드 디렉터리 생성
+mkdir build && cd build
+
+# 설정
+cmake ..
+
+# 빌드
+cmake --build .
+
+# 실행 (선택)
+./bin/database_server --help
+```
+
+### CMake 옵션
+
+| 옵션 | 기본값 | 설명 |
+|------|--------|------|
+| `BUILD_TESTS` | ON | 단위 테스트 빌드 |
+| `BUILD_BENCHMARKS` | OFF | 성능 벤치마크 빌드 |
+| `BUILD_SAMPLES` | OFF | 샘플 애플리케이션 빌드 |
+| `BUILD_MODULES` | OFF | C++20 모듈 라이브러리 빌드 |
+| `BUILD_WITH_MONITORING_SYSTEM` | OFF | 모니터링 통합 활성화 |
+| `BUILD_WITH_CONTAINER_SYSTEM` | ON | 프로토콜 직렬화 (필수, 비활성화 시 빌드 실패) |
+| `ENABLE_COVERAGE` | OFF | 코드 커버리지 활성화 |
+
+### 통합 매크로
+
+소스 코드는 kcenon 생태계 전반에서 통합 게이팅을 위해 `KCENON_WITH_*=1` 통합 매크로를 사용합니다:
+
+| 매크로 | CMake 옵션 | 설명 |
+|--------|------------|------|
+| `KCENON_WITH_CONTAINER_SYSTEM=1` | `BUILD_WITH_CONTAINER_SYSTEM` | Container 직렬화 지원 |
+| `KCENON_WITH_MONITORING_SYSTEM=1` | `BUILD_WITH_MONITORING_SYSTEM` | 모니터링 통합 |
+| `KCENON_WITH_COMMON_SYSTEM=1` | 자동 감지 | Common system 통합 |
+
+CMake는 해당 `BUILD_WITH_*` 옵션이 활성화될 때 `KCENON_WITH_*=1` 전처리기 매크로를 직접 정의합니다. 이 통합 매크로 시스템은 중간 매핑 없이 모든 kcenon 저장소에서 일관된 통합 게이팅을 보장합니다.
+
+### 테스트 실행
+
+```bash
+# 테스트 활성화하여 빌드 (기본값)
+cmake .. -DBUILD_TESTS=ON
+cmake --build .
+
+# 전체 테스트 실행
+ctest --output-on-failure
+
+# 또는 특정 테스트 실행 파일 직접 실행
+./bin/query_protocol_test
+./bin/resilience_test
+./bin/integration_test
+./bin/rate_limiter_test
+./bin/auth_middleware_test
+./bin/connection_pool_test
+./bin/query_cache_test
+```
+
+**현재 테스트 커버리지:**
+- Query Protocol 테스트 (45개)
+  - 쿼리 타입 및 상태 코드 변환
+  - 메시지 헤더 구성
+  - 인증 토큰 검증 및 만료
+  - 쿼리 파라미터 값 타입
+  - 쿼리 요청/응답 직렬화
+  - 잘못된 입력에 대한 오류 처리
+
+- Resilience 테스트 (29개)
+  - 헬스 상태 구조 및 성공률 계산
+  - 헬스 체크 설정 기본값 및 커스터마이징
+  - 재연결 설정 검증
+  - 커넥션 상태 열거형 문자열 변환
+  - null 백엔드 처리를 위한 커넥션 헬스 모니터
+  - 복원력 있는 데이터베이스 커넥션 엣지 케이스
+
+- Integration 테스트 (Phase 3.5)
+  - 인증 미들웨어 인증 흐름
+  - 부하 상태에서의 Rate Limiting 동작
+  - 쿼리 라우터 메트릭 추적
+  - 동시 요청 처리
+  - 전체 파이프라인 처리량 테스트
+  - 오류 처리 시나리오
+
+- Session ID 보안 테스트
+  - 형식 검증 (32자 16진수 문자열)
+  - 100,000개 샘플에 대한 고유성 검증
+  - 엔트로피 추정 (문자당 3.5비트 이상)
+  - 동시 생성 시 스레드 안전성
+  - 성능 검증 (생성당 1μs 미만)
+
+- Rate Limiter 테스트
+  - 슬라이딩 윈도우 알고리즘 정확성
+  - 버스트 처리 및 설정
+  - 차단 지속 시간 동작
+  - 동시 접근 안전성
+  - 클라이언트 독립성 검증
+
+- Auth Middleware 테스트
+  - 토큰 검증 성공/실패 케이스
+  - 토큰 만료 처리
+  - Rate Limiting 통합
+  - 감사 이벤트 발행
+  - 메트릭 수집
+  - 세션 관리
+
+- Connection Pool 테스트
+  - 풀 설정 및 초기화
+  - 커넥션 획득 및 반환
+  - 풀 소진 및 타임아웃 처리
+  - 정상 종료 동작
+  - 헬스 체크 기능
+  - 우선순위 기반 메트릭 추적
+  - 동시 접근 안전성
+
+- Query Cache 테스트 (32개)
+  - 캐시 설정 기본값 및 커스터마이징
+  - 기본 캐시 동작 (get, put, clear)
+  - LRU 퇴거 정책 검증
+  - TTL 기반 만료 처리
+  - 테이블 기반 캐시 무효화
+  - SQL 및 파라미터 기반 캐시 키 생성
+  - 캐시 메트릭 (적중, 미스, 퇴거)
+  - 크기 제한 적용
+  - 동시 접근 시 스레드 안전성
+
+### C++20 모듈
+
+이 프로젝트는 컴파일 시간 개선과 더 나은 캡슐화를 위해 C++20 모듈을 지원합니다.
+
+**요구사항:**
+- Clang 16.0+ 또는 GCC 14.0+ 또는 MSVC 19.29+
+- CMake 3.28+ 권장 (최적의 모듈 지원)
+
+**모듈 빌드:**
+
+```bash
+cmake .. -DBUILD_MODULES=ON
+cmake --build .
+```
+
+**모듈 구조:**
+
+```
+kcenon.database_server              # 주 모듈 인터페이스
+├── :core                           # 서버 앱 및 설정
+├── :gateway                        # 쿼리 프로토콜 및 라우팅
+├── :pooling                        # 커넥션 풀 관리
+├── :resilience                     # 헬스 모니터링 및 복구
+└── :metrics                        # CRTP 기반 메트릭 수집
+```
+
+**사용법:**
+
+```cpp
+import kcenon.database_server;
+
+int main() {
+    database_server::server_app app;
+
+    if (auto result = app.initialize("config.yaml"); !result) {
+        return 1;
+    }
+
+    return app.run();
+}
+```
+
+**파티션 임포트:**
+
+```cpp
+// 게이트웨이 컴포넌트만 임포트
+import kcenon.database_server:gateway;
+
+// 게이트웨이 타입 사용
+database_server::gateway::query_request request("SELECT * FROM users",
+                                                  database_server::gateway::query_type::select);
+```
+
+### 벤치마크 실행
+
+```bash
+# 벤치마크 활성화하여 빌드
+cmake .. -DBUILD_BENCHMARKS=ON
+cmake --build .
+
+# 벤치마크 실행
+./bin/gateway_benchmarks
+```
+
+**성능 벤치마크 (Phase 3.5):**
+- 라우터 라우팅 오버헤드 측정 (목표: < 1ms)
+- 쿼리 처리량 벤치마크 (목표: 10k+ 쿼리/초)
+- 인증 미들웨어 검증 처리량
+- Rate Limiter 성능
+- 직렬화/역직렬화 처리량
+- 지연 시간 분포 (p50, p90, p99)
+- 동시 접근 패턴
+
+## 설정
+
+서버는 설정 파일(기본: `config.conf`)을 사용하여 구성할 수 있습니다:
+
+```conf
+# 서버 식별
+name=my_database_server
+
+# 네트워크 설정
+network.host=0.0.0.0
+network.port=5432
+network.enable_tls=false
+network.max_connections=100
+network.connection_timeout_ms=30000
+
+# 로깅
+logging.level=info
+logging.enable_console=true
+
+# 커넥션 풀 (Phase 2)
+pool.min_connections=5
+pool.max_connections=50
+pool.idle_timeout_ms=60000
+pool.health_check_interval_ms=30000
+
+# 인증 (Phase 3.4)
+auth.enabled=true
+auth.validate_on_each_request=false
+auth.token_refresh_window_ms=300000
+
+# Rate Limiting (Phase 3.4)
+rate_limit.enabled=true
+rate_limit.requests_per_second=100
+rate_limit.burst_size=200
+rate_limit.window_size_ms=1000
+rate_limit.block_duration_ms=60000
+
+# 쿼리 캐시 (Phase 3)
+cache.enabled=true
+cache.max_entries=10000
+cache.ttl_seconds=300
+cache.max_result_size_bytes=1048576
+cache.enable_lru=true
+```
+
+## 사용법
+
+```bash
+# 기본 설정으로 실행
+./database_server
+
+# 사용자 정의 설정 파일로 실행
+./database_server -c /path/to/config.conf
+
+# 도움말 표시
+./database_server --help
+
+# 버전 표시
+./database_server --version
+```
+
+## 개발 로드맵
+
+### Phase 1: 스캐폴딩 및 의존성 설정
+- [x] 기본 디렉터리 구조 생성
+- [x] 의존성과 함께 CMakeLists.txt 구성
+- [x] 기본 server_app 인터페이스 구현
+- [x] main.cpp 진입점 생성
+- [x] 설정 로딩 추가
+
+### Phase 2: 코어 마이그레이션 (완료)
+- [x] database_system에서 connection_pool 마이그레이션
+  - [x] 4단계 우선순위 레벨의 connection_priority 열거형
+  - [x] 우선순위별 추적이 가능한 pool_metrics
+  - [x] 적응형 작업 큐 통합의 connection_pool
+  - [x] 서버 측 커넥션 풀 타입 (`connection_types.h`)
+    - connection_pool_config, connection_stats, connection_wrapper
+    - connection_pool_base 추상 인터페이스
+    - connection_pool 구현
+- [x] database_system에서 resilience 로직 마이그레이션
+  - [x] 하트비트 기반 헬스 추적의 connection_health_monitor
+  - [x] 자동 재연결이 가능한 resilient_database_connection
+- [x] namespace를 database_server::pooling 및 database_server::resilience로 업데이트
+- [x] database_system을 필수 의존성으로 추가
+
+> **참고**: database_system Phase 4.3부터 클라이언트 측 커넥션 풀링이 제거되었습니다
+> (Client Library Diet 이니셔티브). 커넥션 풀링은 이제 database_server 미들웨어를 통해
+> 서버 측에서 처리됩니다. 클라이언트 애플리케이션은 ProxyMode(`set_mode_proxy()`)를
+> 사용하여 database_server를 통해 연결해야 합니다.
+
+### Phase 3: 네트워크 게이트웨이 구현 (현재)
+- [x] Query Protocol 정의 및 구현
+  - [x] query_types.h: 쿼리 타입 및 상태 코드 열거형
+  - [x] query_protocol.h: 요청/응답 메시지 구조
+  - [x] container_system을 사용한 직렬화
+  - [x] 메시지 검증용 단위 테스트 (45개)
+  - [x] 모듈러 구조로 리팩터링 ([#32](https://github.com/kcenon/database_server/issues/32)):
+    - `protocol/serialization_helpers.h`: 공통 유틸리티
+    - `protocol/header_serializer.cpp`: message_header
+    - `protocol/auth_serializer.cpp`: auth_token
+    - `protocol/param_serializer.cpp`: query_param
+    - `protocol/request_serializer.cpp`: query_request
+    - `protocol/response_serializer.cpp`: query_response
+- [x] TCP Listener 구현
+  - [x] gateway_server: kcenon::network::core::messaging_server를 사용한 TCP 서버
+  - [x] 인증 지원이 포함된 클라이언트 세션 관리
+- [x] 쿼리 라우팅 및 로드 밸런싱 구현
+  - [x] query_router: 쿼리를 커넥션 풀로 라우팅
+  - [x] 우선순위 기반 스케줄링 통합
+  - [x] 성능 모니터링을 위한 메트릭 수집
+  - [x] 게이트웨이 및 쿼리 라우터와 server_app 통합
+  - [x] 가상 디스패치 오버헤드 제로의 CRTP 기반 쿼리 핸들러 ([#48](https://github.com/kcenon/database_server/issues/48))
+- [x] 인증 미들웨어 추가 (Phase 3.4)
+  - [x] auth_middleware: 플러거블 검증기를 사용한 토큰 검증
+  - [x] rate_limiter: 버스트 지원이 포함된 슬라이딩 윈도우 Rate Limiting
+  - [x] 보안 이벤트에 대한 감사 로깅
+  - [x] gateway_server 요청 파이프라인과의 통합
+- [x] 통합 테스트 및 벤치마크 작성 (Phase 3.5)
+  - [x] 전체 쿼리 흐름에 대한 통합 테스트
+  - [x] 오류 처리 시나리오 테스트
+  - [x] 성능 벤치마크 (목표: 10k+ 쿼리/초)
+  - [x] 지연 시간 측정 (목표: < 1ms 라우팅 오버헤드)
+- [x] 쿼리 결과 캐시 구현 ([#30](https://github.com/kcenon/database_server/issues/30))
+  - [x] 설정 가능한 최대 항목 수의 LRU 퇴거 정책
+  - [x] 캐시된 결과에 대한 TTL 기반 만료
+  - [x] 쓰기 작업 시 자동 캐시 무효화
+  - [x] 대상 무효화를 위한 SQL 테이블 이름 추출
+  - [x] shared_mutex를 사용한 스레드 안전 구현
+  - [x] 종합적인 캐시 메트릭
+- [x] IExecutor 인터페이스 통합 ([#45](https://github.com/kcenon/database_server/issues/45))
+  - [x] 백그라운드 작업을 위한 선택적 IExecutor 주입
+  - [x] Resilience 모듈: IExecutor를 통한 헬스 모니터링
+  - [x] Gateway 모듈: IExecutor를 통한 비동기 쿼리 실행
+  - [x] Executor 미제공 시 std::async로 폴백
+  - [x] server_app에서 중앙화된 executor 관리
+
+### Phase 4: 기반 시스템 개선 통합 ([#50](https://github.com/kcenon/database_server/issues/50))
+- [x] IExecutor 인터페이스 통합 ([#45](https://github.com/kcenon/database_server/issues/45))
+  - [x] 게이트웨이, 풀링, 복원력 모듈에서 통합 비동기 실행
+  - [x] std::async 폴백이 포함된 선택적 IExecutor 주입
+- [x] Result<T> 패턴 채택 ([#46](https://github.com/kcenon/database_server/issues/46))
+  - [x] 게이트웨이 쿼리 처리에서 타입 안전 오류 처리
+  - [x] 모든 프로토콜 핸들러에서 일관된 Result<T> 반환
+  - [x] 캐시 및 라우터 동작에서 Result<T> 반환
+- [x] C++20 모듈 마이그레이션 ([#47](https://github.com/kcenon/database_server/issues/47))
+  - [x] 주 모듈: `kcenon.database_server`
+  - [x] 파티션: `:core`, `:gateway`, `:pooling`, `:resilience`, `:metrics`
+  - [x] 모듈 임포트를 사용한 깔끔한 의존성 관리
+- [x] 프로토콜 핸들러용 CRTP 패턴 ([#48](https://github.com/kcenon/database_server/issues/48))
+  - [x] 쿼리 처리에서 가상 디스패치 오버헤드 제로
+  - [x] 7개 CRTP 핸들러: select, insert, update, delete, execute, ping, batch
+  - [x] 런타임 다형성을 위한 타입 소거 래퍼
+- [x] CRTP 기반 쿼리 메트릭 수집기 ([#49](https://github.com/kcenon/database_server/issues/49))
+  - [x] `query_collector_base` CRTP 템플릿
+  - [x] 메트릭: 쿼리 실행, 캐시 성능, 풀 활용도, 세션
+  - [x] monitoring_system 패턴과의 통합
+
+## 계획된 기능
+
+다음 기능들이 향후 릴리스에 계획되어 있습니다:
+
+| 기능 | 설명 | 상태 |
+|------|------|------|
+| QUIC 프로토콜 | 내장 TLS를 사용한 고성능 UDP 기반 전송 | 계획됨 |
+| 쿼리 결과 캐시 | TTL 및 LRU 퇴거가 포함된 SELECT 쿼리 결과 인메모리 캐시 | ✅ 완료 ([#30](https://github.com/kcenon/database_server/issues/30)) |
+| IExecutor 통합 | common_system IExecutor 인터페이스를 사용한 통합 비동기 실행 | ✅ 완료 ([#45](https://github.com/kcenon/database_server/issues/45)) |
+| Result<T> 패턴 | common_system Result<T>를 사용한 타입 안전 오류 처리 | ✅ 완료 ([#46](https://github.com/kcenon/database_server/issues/46)) |
+| C++20 모듈 | 파티션 모듈 구조의 모듈러 컴파일 | ✅ 완료 ([#47](https://github.com/kcenon/database_server/issues/47)) |
+| CRTP 쿼리 핸들러 | 쿼리 처리에서 가상 디스패치 오버헤드 제로 | ✅ 완료 ([#48](https://github.com/kcenon/database_server/issues/48)) |
+| CRTP 메트릭 수집기 | monitoring_system 패턴을 따르는 제로 오버헤드 쿼리 메트릭 수집 | ✅ 완료 ([#49](https://github.com/kcenon/database_server/issues/49)) |
+
+## Executor 통합
+
+서버는 중앙화된 스레드 관리를 위해 `common_system`의 선택적 `IExecutor` 주입을 지원합니다. 이를 통해 컴포넌트 간에 단일 스레드 풀을 공유하여 효율적인 리소스 활용이 가능합니다.
+
+### 사용 예제
+
+```cpp
+#include <kcenon/database_server/server_app.h>
+#include <kcenon/thread/adapters/common_executor_adapter.h>
+#include <kcenon/thread/core/thread_pool.h>
+
+// 서버 앱 생성
+database_server::server_app app;
+app.initialize("config.conf");
+
+// 공유 executor 생성 (선택)
+auto pool = std::make_shared<kcenon::thread::thread_pool>("shared_executor", 4);
+pool->start();
+auto executor = kcenon::thread::adapters::common_executor_factory::create_from_thread_pool(pool);
+
+// 통합 스레드 관리를 위한 executor 주입
+app.set_executor(executor);
+
+// 서버 시작 - 비동기 쿼리와 헬스 모니터링이 공유 executor를 사용
+app.run();
+```
+
+### IExecutor 지원 컴포넌트
+
+| 컴포넌트 | 메서드 | 설명 |
+|----------|--------|------|
+| `server_app` | `set_executor()` | 중앙화된 executor 관리 |
+| `query_router` | `set_executor()` | 비동기 쿼리 실행 |
+| `connection_health_monitor` | 생성자 | 백그라운드 헬스 모니터링 |
+| `resilient_database_connection` | 생성자 | 헬스 모니터로 전파 |
+
+Executor가 제공되지 않으면 컴포넌트는 백그라운드 작업을 위해 자동으로 `std::async`로 폴백합니다.
+
+## 메트릭 수집
+
+서버는 제로 오버헤드 수집을 위해 monitoring_system의 수집기 패턴을 따르는 CRTP 기반 메트릭 수집기를 포함합니다.
+
+### 메트릭 카테고리
+
+| 카테고리 | 메트릭 | 설명 |
+|----------|--------|------|
+| 쿼리 실행 | total/success/failed/timeout, latency | 쿼리 성능 추적 |
+| 캐시 성능 | hits/misses, hit ratio, evictions | 캐시 효율성 모니터링 |
+| 풀 활용도 | active/idle 커넥션, acquisition time | 커넥션 풀 상태 |
+| 세션 관리 | active sessions, auth events, duration | 세션 생명주기 추적 |
+
+### 사용 예제
+
+```cpp
+#include <kcenon/database_server/metrics/query_metrics_collector.h>
+
+using namespace database_server::metrics;
+
+// 글로벌 수집기 획득
+auto& collector = get_query_metrics_collector();
+
+// 설정으로 초기화
+collector.initialize({
+    {"enabled", "true"},
+    {"track_query_types", "true"}
+});
+
+// 쿼리 실행 기록
+query_execution exec;
+exec.query_type = "select";
+exec.latency_ns = 1500000;  // 1.5ms
+exec.success = true;
+collector.collect_query_metrics(exec);
+
+// 캐시 동작 기록
+cache_stats cache;
+cache.hit = true;
+collector.collect_cache_metrics(cache);
+
+// 모니터링을 위한 메트릭 획득
+const auto& metrics = collector.get_metrics();
+double avg_latency = metrics.query_metrics.avg_query_latency_ms();
+double cache_hit_ratio = metrics.cache_metrics.cache_hit_ratio();
+```
+
+### Monitoring System 통합
+
+```cpp
+// 모니터링 통합 초기화
+initialize_monitoring_integration("my_database_server");
+
+// 커스텀 모니터링 시스템을 위한 내보내기 콜백 설정
+set_metrics_export_callback([](const std::vector<monitoring_metric>& metrics) {
+    for (const auto& m : metrics) {
+        // 모니터링 시스템으로 내보내기
+        push_to_prometheus(m.name, m.value, m.tags);
+    }
+});
+
+// 현재 메트릭 내보내기
+export_metrics_to_monitoring();
+
+// 헬스 엔드포인트용 메트릭 획득
+auto health_metrics = get_metrics_for_health_endpoint();
+```
+
+## 보안
+
+### Session ID 생성
+
+세션 ID는 암호학적으로 안전한 방법을 사용하여 생성됩니다:
+
+- **128비트 엔트로피**: 예측 불가능성을 위해 두 개의 64비트 랜덤 값 사용
+- **하드웨어 시딩**: 하드웨어 엔트로피를 위해 `std::random_device` 사용
+- **스레드 안전**: 스레드 로컬 RNG로 경합 및 예측 가능성 방지
+- **형식**: 32자 소문자 16진수 문자열
+
+세션 ID 형식은 예측 가능한 타임스탬프-카운터 패턴에서 안전한 랜덤 값으로 변경되었습니다. 이전 형식(`session_TIMESTAMP_COUNTER`)은 ID 예측을 통한 세션 하이재킹에 취약했습니다.
+
+### 보안 모범 사례
+
+1. **인증**: 프로덕션 환경에서 `auth.enabled=true` 활성화
+2. **Rate Limiting**: 남용 방지를 위해 적절한 Rate Limit 구성
+3. **TLS**: 암호화된 연결을 위해 TLS 활성화 (`network.enable_tls=true`)
+4. **로깅**: 프로덕션 환경에서 전체 세션 ID 로깅 방지
+
+## 라이선스
+
+BSD 3-Clause License - 자세한 내용은 [LICENSE](LICENSE)를 참조하세요.
+
+## CI/CD
+
+이 프로젝트는 database_system 파이프라인과 일치하는 종합적인 CI/CD 워크플로우를 포함합니다:
+
+### 핵심 워크플로우
+
+| 워크플로우 | 설명 | 상태 |
+|-----------|------|------|
+| `ci.yml` | 멀티 플랫폼 빌드 (Ubuntu, macOS, Windows) | 활성 |
+| `integration-tests.yml` | 커버리지 포함 통합 테스트 | 활성 |
+| `coverage.yml` | Codecov 코드 커버리지 | 활성 |
+
+### 품질 게이트
+
+| 워크플로우 | 설명 | 상태 |
+|-----------|------|------|
+| `static-analysis.yml` | clang-tidy 및 cppcheck 분석 | 활성 |
+| `sanitizers.yml` | ASan, TSan, UBSan 검사 | 활성 |
+
+### 보안 및 문서
+
+| 워크플로우 | 설명 | 상태 |
+|-----------|------|------|
+| `dependency-security-scan.yml` | Trivy 취약점 스캐닝 | 활성 |
+| `sbom.yml` | SBOM 생성 (CycloneDX, SPDX) | 활성 |
+| `build-Doxygen.yaml` | API 문서 생성 | 활성 |
+
+### 성능
+
+| 워크플로우 | 설명 | 상태 |
+|-----------|------|------|
+| `benchmarks.yml` | 성능 회귀 테스트 | 활성 |
+
+## 관련 프로젝트
+
+- [common_system](../common_system) - 핵심 유틸리티 및 인터페이스
+- [thread_system](../thread_system) - 스레딩 및 작업 스케줄링
+- [network_system](../network_system) - 네트워크 통신
+- [database_system](../database_system) - 데이터베이스 클라이언트 라이브러리

--- a/README.kr.md
+++ b/README.kr.md
@@ -71,16 +71,16 @@ Database Server는 kcenon 통합 시스템 아키텍처에서 모놀리식 라�
 ### 빌드 단계
 
 ```bash
-# 빌드 디렉터리 생성
+# Create build directory
 mkdir build && cd build
 
-# 설정
+# Configure
 cmake ..
 
-# 빌드
+# Build
 cmake --build .
 
-# 실행 (선택)
+# Run (optional)
 ./bin/database_server --help
 ```
 
@@ -111,14 +111,14 @@ CMake는 해당 `BUILD_WITH_*` 옵션이 활성화될 때 `KCENON_WITH_*=1` 전�
 ### 테스트 실행
 
 ```bash
-# 테스트 활성화하여 빌드 (기본값)
+# Build with tests enabled (default)
 cmake .. -DBUILD_TESTS=ON
 cmake --build .
 
-# 전체 테스트 실행
+# Run all tests
 ctest --output-on-failure
 
-# 또는 특정 테스트 실행 파일 직접 실행
+# Or run specific test executable directly
 ./bin/query_protocol_test
 ./bin/resilience_test
 ./bin/integration_test
@@ -213,12 +213,12 @@ cmake --build .
 **모듈 구조:**
 
 ```
-kcenon.database_server              # 주 모듈 인터페이스
-├── :core                           # 서버 앱 및 설정
-├── :gateway                        # 쿼리 프로토콜 및 라우팅
-├── :pooling                        # 커넥션 풀 관리
-├── :resilience                     # 헬스 모니터링 및 복구
-└── :metrics                        # CRTP 기반 메트릭 수집
+kcenon.database_server              # Primary module interface
+├── :core                           # Server app and configuration
+├── :gateway                        # Query protocol and routing
+├── :pooling                        # Connection pool management
+├── :resilience                     # Health monitoring and recovery
+└── :metrics                        # CRTP-based metrics collection
 ```
 
 **사용법:**
@@ -240,10 +240,10 @@ int main() {
 **파티션 임포트:**
 
 ```cpp
-// 게이트웨이 컴포넌트만 임포트
+// Import only gateway components
 import kcenon.database_server:gateway;
 
-// 게이트웨이 타입 사용
+// Use gateway types
 database_server::gateway::query_request request("SELECT * FROM users",
                                                   database_server::gateway::query_type::select);
 ```
@@ -251,11 +251,11 @@ database_server::gateway::query_request request("SELECT * FROM users",
 ### 벤치마크 실행
 
 ```bash
-# 벤치마크 활성화하여 빌드
+# Build with benchmarks enabled
 cmake .. -DBUILD_BENCHMARKS=ON
 cmake --build .
 
-# 벤치마크 실행
+# Run benchmarks
 ./bin/gateway_benchmarks
 ```
 
@@ -273,27 +273,27 @@ cmake --build .
 서버는 설정 파일(기본: `config.conf`)을 사용하여 구성할 수 있습니다:
 
 ```conf
-# 서버 식별
+# Server identification
 name=my_database_server
 
-# 네트워크 설정
+# Network settings
 network.host=0.0.0.0
 network.port=5432
 network.enable_tls=false
 network.max_connections=100
 network.connection_timeout_ms=30000
 
-# 로깅
+# Logging
 logging.level=info
 logging.enable_console=true
 
-# 커넥션 풀 (Phase 2)
+# Connection pool (Phase 2)
 pool.min_connections=5
 pool.max_connections=50
 pool.idle_timeout_ms=60000
 pool.health_check_interval_ms=30000
 
-# 인증 (Phase 3.4)
+# Authentication (Phase 3.4)
 auth.enabled=true
 auth.validate_on_each_request=false
 auth.token_refresh_window_ms=300000
@@ -305,7 +305,7 @@ rate_limit.burst_size=200
 rate_limit.window_size_ms=1000
 rate_limit.block_duration_ms=60000
 
-# 쿼리 캐시 (Phase 3)
+# Query Cache (Phase 3)
 cache.enabled=true
 cache.max_entries=10000
 cache.ttl_seconds=300
@@ -316,16 +316,16 @@ cache.enable_lru=true
 ## 사용법
 
 ```bash
-# 기본 설정으로 실행
+# Run with default configuration
 ./database_server
 
-# 사용자 정의 설정 파일로 실행
+# Run with custom configuration file
 ./database_server -c /path/to/config.conf
 
-# 도움말 표시
+# Show help
 ./database_server --help
 
-# 버전 표시
+# Show version
 ./database_server --version
 ```
 
@@ -450,19 +450,19 @@ cache.enable_lru=true
 #include <kcenon/thread/adapters/common_executor_adapter.h>
 #include <kcenon/thread/core/thread_pool.h>
 
-// 서버 앱 생성
+// Create server app
 database_server::server_app app;
 app.initialize("config.conf");
 
-// 공유 executor 생성 (선택)
+// Create shared executor (optional)
 auto pool = std::make_shared<kcenon::thread::thread_pool>("shared_executor", 4);
 pool->start();
 auto executor = kcenon::thread::adapters::common_executor_factory::create_from_thread_pool(pool);
 
-// 통합 스레드 관리를 위한 executor 주입
+// Inject executor for unified thread management
 app.set_executor(executor);
 
-// 서버 시작 - 비동기 쿼리와 헬스 모니터링이 공유 executor를 사용
+// Start server - async queries and health monitoring will use shared executor
 app.run();
 ```
 
@@ -497,28 +497,28 @@ Executor가 제공되지 않으면 컴포넌트는 백그라운드 작업을 위
 
 using namespace database_server::metrics;
 
-// 글로벌 수집기 획득
+// Get global collector
 auto& collector = get_query_metrics_collector();
 
-// 설정으로 초기화
+// Initialize with configuration
 collector.initialize({
     {"enabled", "true"},
     {"track_query_types", "true"}
 });
 
-// 쿼리 실행 기록
+// Record query execution
 query_execution exec;
 exec.query_type = "select";
 exec.latency_ns = 1500000;  // 1.5ms
 exec.success = true;
 collector.collect_query_metrics(exec);
 
-// 캐시 동작 기록
+// Record cache operation
 cache_stats cache;
 cache.hit = true;
 collector.collect_cache_metrics(cache);
 
-// 모니터링을 위한 메트릭 획득
+// Get metrics for monitoring
 const auto& metrics = collector.get_metrics();
 double avg_latency = metrics.query_metrics.avg_query_latency_ms();
 double cache_hit_ratio = metrics.cache_metrics.cache_hit_ratio();
@@ -527,21 +527,21 @@ double cache_hit_ratio = metrics.cache_metrics.cache_hit_ratio();
 ### Monitoring System 통합
 
 ```cpp
-// 모니터링 통합 초기화
+// Initialize monitoring integration
 initialize_monitoring_integration("my_database_server");
 
-// 커스텀 모니터링 시스템을 위한 내보내기 콜백 설정
+// Set export callback for custom monitoring systems
 set_metrics_export_callback([](const std::vector<monitoring_metric>& metrics) {
     for (const auto& m : metrics) {
-        // 모니터링 시스템으로 내보내기
+        // Export to your monitoring system
         push_to_prometheus(m.name, m.value, m.tags);
     }
 });
 
-// 현재 메트릭 내보내기
+// Export current metrics
 export_metrics_to_monitoring();
 
-// 헬스 엔드포인트용 메트릭 획득
+// Get metrics for health endpoint
 auto health_metrics = get_metrics_for_health_endpoint();
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> 🇰🇷 [한국어 버전](README.kr.md)
+
 # Database Server
 
 A high-performance database gateway middleware server that provides connection pooling, query routing, and caching capabilities.

--- a/docs/ARCHITECTURE.kr.md
+++ b/docs/ARCHITECTURE.kr.md
@@ -1,0 +1,359 @@
+> 🇺🇸 [English Version](ARCHITECTURE.md)
+
+# 아키텍처
+
+## 개요
+
+Database Server는 클라이언트 애플리케이션과 물리적 데이터베이스(PostgreSQL, MySQL 등) 사이에 위치하는 게이트웨이 미들웨어입니다. 투명한 미들웨어 계층으로서 커넥션 풀링, 쿼리 라우팅, 인증, Rate Limiting, 캐싱 기능을 제공합니다.
+
+### 설계 목표
+
+| 목표 | 설명 |
+|------|------|
+| **성능** | 1ms 미만의 라우팅 오버헤드, 10k+ 쿼리/초 처리량 |
+| **신뢰성** | 자동 헬스 모니터링 및 커넥션 복구 |
+| **보안** | 토큰 기반 인증, Rate Limiting, 암호학적 세션 ID |
+| **확장성** | 가상 디스패치 오버헤드 제로의 CRTP 기반 핸들러 |
+| **관측성** | monitoring_system 패턴을 따르는 종합적인 메트릭 수집 |
+
+## 시스템 구조
+
+서버는 각각 명확한 책임을 가진 6개 모듈로 구성됩니다:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        database_server                          │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  ┌──────────┐  ┌───────────┐  ┌──────────┐  ┌──────────────┐  │
+│  │   Core   │  │  Gateway  │  │ Pooling  │  │  Resilience  │  │
+│  │          │  │           │  │          │  │              │  │
+│  │ server_  │  │ gateway_  │  │ conn_    │  │ health_      │  │
+│  │ app      │  │ server    │  │ pool     │  │ monitor      │  │
+│  │ server_  │  │ query_    │  │ pool_    │  │ resilient_   │  │
+│  │ config   │  │ router    │  │ metrics  │  │ connection   │  │
+│  │          │  │ query_    │  │          │  │              │  │
+│  │          │  │ handlers  │  │          │  │              │  │
+│  │          │  │ auth_     │  │          │  │              │  │
+│  │          │  │ middleware│  │          │  │              │  │
+│  │          │  │ query_    │  │          │  │              │  │
+│  │          │  │ cache     │  │          │  │              │  │
+│  └──────────┘  └───────────┘  └──────────┘  └──────────────┘  │
+│                                                                 │
+│  ┌──────────┐  ┌───────────┐                                   │
+│  │ Metrics  │  │  Logging  │                                   │
+│  │          │  │           │                                   │
+│  │ query_   │  │ console_  │                                   │
+│  │ metrics_ │  │ logger    │                                   │
+│  │ collector│  │           │                                   │
+│  └──────────┘  └───────────┘                                   │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 모듈 요약
+
+| 모듈 | 네임스페이스 | 책임 |
+|------|-------------|------|
+| **Core** | `database_server` | 애플리케이션 생명주기, 설정 로딩, 시그널 처리 |
+| **Gateway** | `database_server::gateway` | TCP 서버, 쿼리 프로토콜, 라우팅, 인증, 캐싱 |
+| **Pooling** | `database_server::pooling` | 우선순위 기반 스케줄링의 커넥션 풀 관리 |
+| **Resilience** | `database_server::resilience` | 헬스 모니터링, 자동 재연결 |
+| **Metrics** | `database_server::metrics` | CRTP 기반 제로 오버헤드 쿼리 메트릭 수집 |
+| **Logging** | `database_server::logging` | 설정 가능한 레벨의 콘솔 로깅 |
+
+## 핵심 컴포넌트
+
+### Core 모듈
+
+**`server_app`**은 모든 하위 시스템을 소유하고 초기화하는 중앙 오케스트레이터입니다:
+
+```
+server_app
+├── server_config          # 설정 파일 파싱
+├── gateway_server         # TCP 리스너
+├── query_router           # 쿼리 디스패치
+├── connection_pool        # 데이터베이스 커넥션
+├── query_cache            # 선택적 결과 캐시
+└── IExecutor (optional)   # 공유 스레드 풀
+```
+
+**`server_config`**는 네트워크, 풀링, 인증, Rate Limiting, 캐싱 파라미터 섹션이 포함된 `config.conf` 파일을 파싱합니다.
+
+### Gateway 모듈
+
+Gateway 모듈은 모든 네트워크 대면 관심사를 처리합니다:
+
+- **`gateway_server`**: `network_system::messaging_server` 기반의 TCP 서버. 인증 지원이 포함된 클라이언트 세션을 관리합니다.
+- **`query_router`**: 수신 쿼리를 커넥션 풀로 라우팅합니다. 우선순위 기반 스케줄링의 로드 밸런싱을 구현하고 라우팅 메트릭을 수집합니다.
+- **`query_handlers`**: 7개의 CRTP 기반 핸들러(select, insert, update, delete, execute, ping, batch)가 가상 디스패치 오버헤드 없이 쿼리를 처리합니다. 동적 디스패치가 필요한 경우 타입 소거 래퍼가 런타임 다형성을 제공합니다.
+- **`auth_middleware`**: 플러거블 검증기를 사용한 토큰 기반 인증. Rate Limiting을 통합하고 보안 모니터링을 위한 감사 이벤트를 발행합니다.
+- **`rate_limiter`**: 버스트 지원과 설정 가능한 차단 지속 시간이 포함된 슬라이딩 윈도우 알고리즘.
+- **`query_cache`**: TTL 기반 만료가 포함된 LRU 캐시. SQL 문에서 테이블 이름을 추출하여 쓰기 작업 시 캐시 항목을 자동으로 무효화합니다. `shared_mutex`를 통한 스레드 안전.
+- **`session_id_generator`**: 하드웨어 엔트로피와 스레드 로컬 RNG를 사용하여 암호학적으로 안전한 128비트 세션 ID를 생성합니다.
+
+#### Query Protocol
+
+프로토콜 계층은 클라이언트-서버 메시지의 직렬화를 처리합니다:
+
+```
+protocol/
+├── serialization_helpers.h    # 공통 유틸리티
+├── header_serializer.cpp      # message_header
+├── auth_serializer.cpp        # auth_token
+├── param_serializer.cpp       # query_param
+├── request_serializer.cpp     # query_request
+└── response_serializer.cpp    # query_response
+```
+
+모든 직렬화는 `container_system`을 사용한 바이너리 인코딩을 사용하며, 타입 안전 오류 처리를 위해 `Result<T>` 반환 타입을 사용합니다.
+
+### Pooling 모듈
+
+**`connection_pool`**은 다음 기능으로 데이터베이스 커넥션을 관리합니다:
+
+- **우선순위 기반 스케줄링**: 기아 방지를 위한 에이징이 포함된 4단계 우선순위 레벨
+- **커넥션 생명주기**: 획득, 반환, 헬스 추적, 정상 종료
+- **취소 토큰**: 협력적 종료 시그널링 지원
+- **풀 메트릭**: 활성/유휴 카운트, 획득 지연, 우선순위별 추적
+
+### Resilience 모듈
+
+- **`connection_health_monitor`**: 설정 가능한 간격의 하트비트 기반 헬스 체크. 커넥션 헬스 상태와 성공률을 보고합니다. 백그라운드 모니터링을 위한 선택적 `IExecutor`를 지원합니다.
+- **`resilient_database_connection`**: 자동 재연결로 데이터베이스 커넥션을 래핑합니다. 설정 가능한 백오프 전략과 커넥션 상태 추적.
+
+### Metrics 모듈
+
+**`query_metrics_collector`**는 `monitoring_system`의 CRTP 패턴을 따릅니다:
+
+```cpp
+template <typename Derived>
+class query_collector_base {
+    // 제로 가상 디스패치 - 컴파일 타임에 해결
+    void collect(const query_execution& exec) {
+        static_cast<Derived*>(this)->do_collect(exec);
+    }
+};
+```
+
+4가지 메트릭 카테고리를 추적합니다:
+- **쿼리 실행**: 카운트, 지연, 성공/실패율, 타임아웃
+- **캐시 성능**: Hit/Miss 비율, 퇴거
+- **풀 활용도**: 활성/유휴 커넥션, 획득 시간
+- **세션 관리**: 활성 세션, 인증 이벤트, 지속 시간
+
+## 데이터 흐름
+
+### 쿼리 요청 흐름
+
+```
+Client Application
+    │
+    ▼
+┌─────────────────┐
+│  gateway_server  │  1. TCP 연결 수락
+│  (TCP Listener)  │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ auth_middleware  │  2. 토큰 검증, Rate Limit 확인
+│ (rate_limiter)  │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│  query_router   │  3. 요청 역직렬화, 핸들러 선택
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│  query_cache    │  4. 캐시 확인 (SELECT만 해당)
+│  (if enabled)   │     Hit → 캐시된 결과 반환
+└────────┬────────┘
+         │ Miss
+         ▼
+┌─────────────────┐
+│ connection_pool │  5. 커넥션 획득 (우선순위 기반)
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ Physical Database│  6. 쿼리 실행
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ query_cache     │  7. 결과 저장 (SELECT) 또는
+│                 │     무효화 (INSERT/UPDATE/DELETE)
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│  query_router   │  8. 응답 직렬화, 메트릭 수집
+└────────┬────────┘
+         │
+         ▼
+Client Application
+```
+
+### 쓰기 쿼리 무효화
+
+쓰기 작업(INSERT, UPDATE, DELETE)이 처리되면 캐시는 SQL 문에서 테이블 이름을 추출하고 해당 테이블의 모든 캐시 항목을 무효화합니다. 이를 통해 수동 무효화 없이 캐시 일관성을 보장합니다.
+
+## 스레드 모델
+
+### 동시성 설계
+
+서버는 다양한 스레딩 전략을 조합하여 사용합니다:
+
+| 컴포넌트 | 스레딩 모델 | 동기화 |
+|----------|------------|--------|
+| `gateway_server` | 이벤트 기반 (network_system) | mutex 보호 세션 맵 |
+| `query_router` | IExecutor를 통한 비동기 실행 | lock-free 메트릭 수집 |
+| `connection_pool` | 획득 시 condition variable | mutex 보호 풀 상태 |
+| `query_cache` | 리더-라이터 패턴 | `shared_mutex` (읽기 중심 워크로드) |
+| `health_monitor` | 주기적 백그라운드 작업 | 원자적 헬스 상태 |
+| `rate_limiter` | 클라이언트별 추적 | 클라이언트 버킷별 mutex |
+| `session_id_gen` | 스레드 로컬 RNG | 동기화 불필요 |
+
+### IExecutor 통합
+
+컴포넌트는 통합 스레드 관리를 위해 선택적으로 `IExecutor`를 받습니다:
+
+```
+server_app
+    │
+    ├── set_executor(executor)
+    │       │
+    │       ├── query_router.set_executor()
+    │       │       └── 비동기 쿼리 실행
+    │       │
+    │       └── connection_health_monitor(executor)
+    │               └── 백그라운드 헬스 체크
+    │
+    └── (executor 없음)
+            └── std::async로 폴백
+```
+
+이를 통해 모든 컴포넌트에서 단일 스레드 풀을 공유하여 효율적인 리소스 활용이 가능합니다.
+
+### 스레드 안전 보장
+
+- 별도 문서가 없는 한 모든 공개 API는 스레드 안전합니다
+- 내부 상태는 적절한 동기화 프리미티브로 보호됩니다
+- 세션 ID는 경합을 방지하기 위해 스레드 로컬 RNG를 사용합니다
+- 메트릭 수집은 가능한 경우 원자적 연산을 사용합니다
+
+## 의존성
+
+### 생태계 의존성 그래프
+
+```
+                    ┌───────────────┐
+                    │ common_system │  Tier 0
+                    │  (Result<T>,  │
+                    │   IExecutor)  │
+                    └───────┬───────┘
+                            │
+              ┌─────────────┼─────────────┐
+              ▼             ▼             ▼
+     ┌────────────┐  ┌───────────┐  ┌──────────────┐
+     │thread_system│  │container_ │  │database_system│  Tier 1-2
+     │ (job queue, │  │system     │  │ (DB backend, │
+     │  pool)      │  │(serialize)│  │  interfaces) │
+     └──────┬─────┘  └─────┬─────┘  └──────┬───────┘
+            │               │               │
+            ▼               │               │
+     ┌──────────────┐      │               │
+     │network_system│      │               │
+     │ (TCP server) │ Tier 4               │
+     └──────┬───────┘      │               │
+            │               │               │
+            ▼               ▼               ▼
+     ┌─────────────────────────────────────────┐
+     │           database_server               │
+     │  (gateway middleware)                   │
+     └─────────────────────────────────────────┘
+
+     Optional: monitoring_system (Tier 3) for metrics export
+```
+
+### 의존성 역할
+
+| 의존성 | Tier | database_server에서의 역할 |
+|--------|------|-----------------------------|
+| `common_system` | 0 | 오류 처리를 위한 `Result<T>`, 비동기 실행을 위한 `IExecutor`, 로깅 인터페이스 |
+| `thread_system` | 1 | 작업 스케줄링, 스레드 풀 관리, 적응형 작업 큐 |
+| `container_system` | 1 | 쿼리 프로토콜 메시지의 바이너리 직렬화 |
+| `database_system` | 2 | 데이터베이스 백엔드 인터페이스, 커넥션 타입, 쿼리 실행 |
+| `network_system` | 4 | TCP 서버 구현 (`messaging_server`) |
+| `monitoring_system` | 3 | 선택적 메트릭 내보내기 및 헬스 엔드포인트 통합 |
+
+## C++20 모듈 구조
+
+프로젝트는 컴파일 시간 개선과 캡슐화를 위해 C++20 모듈을 지원합니다:
+
+```
+kcenon.database_server                    # 주 모듈 인터페이스
+│
+├── kcenon.database_server:core           # server_app, server_config
+├── kcenon.database_server:gateway        # gateway_server, query_router,
+│                                         # query_handlers, auth_middleware,
+│                                         # query_cache, query_protocol
+├── kcenon.database_server:pooling        # connection_pool, connection_types,
+│                                         # connection_priority, pool_metrics
+├── kcenon.database_server:resilience     # connection_health_monitor,
+│                                         # resilient_database_connection
+└── kcenon.database_server:metrics        # query_metrics_collector,
+                                          # query_collector_base
+```
+
+각 파티션은 공개 API만 내보내어 명확한 모듈 경계를 제공하고 의도하지 않은 내부 의존성을 방지합니다.
+
+## 설계 패턴
+
+### CRTP (Curiously Recurring Template Pattern)
+
+제로 오버헤드 다형성을 위해 두 영역에서 사용됩니다:
+
+1. **쿼리 핸들러**: 7개의 핸들러 타입(select, insert, update, delete, execute, ping, batch)이 CRTP 기반 클래스를 상속합니다. 동적 디스패치가 필요한 경우 타입 소거 래퍼가 런타임 다형성을 제공합니다.
+
+2. **메트릭 수집기**: `query_collector_base<Derived>`는 `monitoring_system`에서 확립된 패턴을 따라 메트릭 수집의 컴파일 타임 디스패치를 가능하게 합니다.
+
+### Result<T> 패턴
+
+모든 프로토콜 동작과 실패 가능한 함수는 `common_system`의 `Result<T>`를 반환하여 다음을 제공합니다:
+- 예외 없는 타입 안전 오류 전파
+- 모든 모듈에서 일관된 오류 처리
+- 조합 가능한 오류 체인
+
+### 설정 기반 아키텍처
+
+서버 동작은 코드 변경 없이 `config.conf`를 통해 완전히 설정 가능합니다:
+- 네트워크 파라미터 (호스트, 포트, TLS, 최대 커넥션)
+- 풀 크기 (최소/최대 커넥션, 타임아웃)
+- 인증 및 Rate Limiting 정책
+- 캐시 파라미터 (최대 항목, TTL, 크기 제한)
+
+## 보안 고려사항
+
+### 인증 흐름
+
+1. 클라이언트가 TCP로 연결하고 첫 번째 메시지에 `auth_token`을 전송
+2. `auth_middleware`가 플러거블 검증기를 사용하여 토큰 검증
+3. Rate Limiter가 클라이언트별 요청 빈도 확인
+4. 성공 시, 안전한 세션 ID가 생성되어 커넥션에 연결
+5. 이후 요청은 상태 유지 작업을 위해 세션을 참조
+
+### Session ID 보안
+
+세션 ID는 128비트 암호학적 무작위성을 사용합니다:
+- `std::random_device`(하드웨어 엔트로피)에서 두 개의 64비트 값
+- 스레드별로 시드되는 스레드 로컬 `std::mt19937_64`
+- 출력: 32자 소문자 16진수 문자열
+- 검증: 100k 샘플에서 문자당 3.5비트 이상의 엔트로피
+
+---
+
+*버전: 1.0.0 | 최종 업데이트: 2026-02-22*

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,359 @@
+> 🇰🇷 [한국어 버전](ARCHITECTURE.kr.md)
+
+# Architecture
+
+## Overview
+
+Database Server is a gateway middleware that sits between client applications and physical databases (PostgreSQL, MySQL, etc.). It provides connection pooling, query routing, authentication, rate limiting, and caching as a transparent middleware layer.
+
+### Design Goals
+
+| Goal | Description |
+|------|-------------|
+| **Performance** | Sub-millisecond routing overhead, 10k+ queries/sec throughput |
+| **Reliability** | Automatic health monitoring and connection recovery |
+| **Security** | Token-based authentication, rate limiting, cryptographic session IDs |
+| **Extensibility** | CRTP-based handlers for zero virtual dispatch overhead |
+| **Observability** | Comprehensive metrics collection following monitoring_system patterns |
+
+## System Structure
+
+The server is organized into six modules, each with a distinct responsibility:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        database_server                          │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  ┌──────────┐  ┌───────────┐  ┌──────────┐  ┌──────────────┐  │
+│  │   Core   │  │  Gateway  │  │ Pooling  │  │  Resilience  │  │
+│  │          │  │           │  │          │  │              │  │
+│  │ server_  │  │ gateway_  │  │ conn_    │  │ health_      │  │
+│  │ app      │  │ server    │  │ pool     │  │ monitor      │  │
+│  │ server_  │  │ query_    │  │ pool_    │  │ resilient_   │  │
+│  │ config   │  │ router    │  │ metrics  │  │ connection   │  │
+│  │          │  │ query_    │  │          │  │              │  │
+│  │          │  │ handlers  │  │          │  │              │  │
+│  │          │  │ auth_     │  │          │  │              │  │
+│  │          │  │ middleware│  │          │  │              │  │
+│  │          │  │ query_    │  │          │  │              │  │
+│  │          │  │ cache     │  │          │  │              │  │
+│  └──────────┘  └───────────┘  └──────────┘  └──────────────┘  │
+│                                                                 │
+│  ┌──────────┐  ┌───────────┐                                   │
+│  │ Metrics  │  │  Logging  │                                   │
+│  │          │  │           │                                   │
+│  │ query_   │  │ console_  │                                   │
+│  │ metrics_ │  │ logger    │                                   │
+│  │ collector│  │           │                                   │
+│  └──────────┘  └───────────┘                                   │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Module Summary
+
+| Module | Namespace | Responsibility |
+|--------|-----------|----------------|
+| **Core** | `database_server` | Application lifecycle, configuration loading, signal handling |
+| **Gateway** | `database_server::gateway` | TCP server, query protocol, routing, authentication, caching |
+| **Pooling** | `database_server::pooling` | Connection pool management with priority-based scheduling |
+| **Resilience** | `database_server::resilience` | Health monitoring, automatic reconnection |
+| **Metrics** | `database_server::metrics` | CRTP-based zero-overhead query metrics collection |
+| **Logging** | `database_server::logging` | Console logging with configurable levels |
+
+## Core Components
+
+### Core Module
+
+**`server_app`** is the central orchestrator that owns and initializes all subsystems:
+
+```
+server_app
+├── server_config          # Configuration file parsing
+├── gateway_server         # TCP listener
+├── query_router           # Query dispatch
+├── connection_pool        # Database connections
+├── query_cache            # Optional result cache
+└── IExecutor (optional)   # Shared thread pool
+```
+
+**`server_config`** parses `config.conf` files with sections for network, pooling, authentication, rate limiting, and caching parameters.
+
+### Gateway Module
+
+The gateway module handles all network-facing concerns:
+
+- **`gateway_server`**: TCP server built on `network_system::messaging_server`. Manages client sessions with authentication support.
+- **`query_router`**: Routes incoming queries to the connection pool. Implements load balancing with priority-based scheduling and collects routing metrics.
+- **`query_handlers`**: Seven CRTP-based handlers (select, insert, update, delete, execute, ping, batch) that process queries with zero virtual dispatch overhead. A type erasure wrapper provides runtime polymorphism when needed.
+- **`auth_middleware`**: Token-based authentication with pluggable validators. Integrates rate limiting and emits audit events for security monitoring.
+- **`rate_limiter`**: Sliding window algorithm with burst support and configurable block duration.
+- **`query_cache`**: LRU cache with TTL-based expiration. Automatically invalidates cache entries on write operations by extracting table names from SQL statements. Thread-safe via `shared_mutex`.
+- **`session_id_generator`**: Generates cryptographically secure 128-bit session IDs using hardware entropy and thread-local RNG.
+
+#### Query Protocol
+
+The protocol layer handles serialization of client-server messages:
+
+```
+protocol/
+├── serialization_helpers.h    # Common utilities
+├── header_serializer.cpp      # message_header
+├── auth_serializer.cpp        # auth_token
+├── param_serializer.cpp       # query_param
+├── request_serializer.cpp     # query_request
+└── response_serializer.cpp    # query_response
+```
+
+All serialization uses `container_system` for binary encoding, with `Result<T>` return types for type-safe error handling.
+
+### Pooling Module
+
+**`connection_pool`** manages database connections with:
+
+- **Priority-based scheduling**: Four priority levels with aging to prevent starvation
+- **Connection lifecycle**: Acquisition, release, health tracking, and graceful shutdown
+- **Cancellation tokens**: Support for cooperative shutdown signaling
+- **Pool metrics**: Active/idle counts, acquisition latency, priority-specific tracking
+
+### Resilience Module
+
+- **`connection_health_monitor`**: Heartbeat-based health checking with configurable intervals. Reports connection health status and success rates. Supports optional `IExecutor` for background monitoring.
+- **`resilient_database_connection`**: Wraps database connections with automatic reconnection. Configurable backoff strategy and connection state tracking.
+
+### Metrics Module
+
+**`query_metrics_collector`** follows the CRTP pattern from `monitoring_system`:
+
+```cpp
+template <typename Derived>
+class query_collector_base {
+    // Zero virtual dispatch - resolved at compile time
+    void collect(const query_execution& exec) {
+        static_cast<Derived*>(this)->do_collect(exec);
+    }
+};
+```
+
+Tracks four metric categories:
+- **Query execution**: Count, latency, success/failure rates, timeouts
+- **Cache performance**: Hit/miss ratio, evictions
+- **Pool utilization**: Active/idle connections, acquisition time
+- **Session management**: Active sessions, auth events, duration
+
+## Data Flow
+
+### Query Request Flow
+
+```
+Client Application
+    │
+    ▼
+┌─────────────────┐
+│  gateway_server  │  1. Accept TCP connection
+│  (TCP Listener)  │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ auth_middleware  │  2. Validate token, check rate limit
+│ (rate_limiter)  │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│  query_router   │  3. Deserialize request, select handler
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│  query_cache    │  4. Check cache (SELECT only)
+│  (if enabled)   │     Hit → return cached result
+└────────┬────────┘
+         │ Miss
+         ▼
+┌─────────────────┐
+│ connection_pool │  5. Acquire connection (priority-based)
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ Physical Database│  6. Execute query
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ query_cache     │  7. Store result (SELECT) or
+│                 │     invalidate (INSERT/UPDATE/DELETE)
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│  query_router   │  8. Serialize response, collect metrics
+└────────┬────────┘
+         │
+         ▼
+Client Application
+```
+
+### Write Query Invalidation
+
+When a write operation (INSERT, UPDATE, DELETE) is processed, the cache extracts table names from the SQL statement and invalidates all cached entries for those tables. This ensures cache consistency without requiring manual invalidation.
+
+## Thread Model
+
+### Concurrency Design
+
+The server uses a combination of threading strategies:
+
+| Component | Threading Model | Synchronization |
+|-----------|----------------|-----------------|
+| `gateway_server` | Event-driven (network_system) | Session map with mutex |
+| `query_router` | Async execution via IExecutor | Lock-free metrics collection |
+| `connection_pool` | Condition variable for acquisition | Mutex-protected pool state |
+| `query_cache` | Reader-writer pattern | `shared_mutex` (read-heavy workload) |
+| `health_monitor` | Periodic background task | Atomic health status |
+| `rate_limiter` | Per-client tracking | Mutex per client bucket |
+| `session_id_gen` | Thread-local RNG | No synchronization needed |
+
+### IExecutor Integration
+
+Components optionally accept an `IExecutor` for unified thread management:
+
+```
+server_app
+    │
+    ├── set_executor(executor)
+    │       │
+    │       ├── query_router.set_executor()
+    │       │       └── Async query execution
+    │       │
+    │       └── connection_health_monitor(executor)
+    │               └── Background health checks
+    │
+    └── (no executor)
+            └── Falls back to std::async
+```
+
+This allows sharing a single thread pool across all components for efficient resource utilization.
+
+### Thread Safety Guarantees
+
+- All public APIs are thread-safe unless documented otherwise
+- Internal state is protected by appropriate synchronization primitives
+- Session IDs use thread-local RNG to avoid contention
+- Metrics collection uses atomic operations where possible
+
+## Dependencies
+
+### Ecosystem Dependency Graph
+
+```
+                    ┌───────────────┐
+                    │ common_system │  Tier 0
+                    │  (Result<T>,  │
+                    │   IExecutor)  │
+                    └───────┬───────┘
+                            │
+              ┌─────────────┼─────────────┐
+              ▼             ▼             ▼
+     ┌────────────┐  ┌───────────┐  ┌──────────────┐
+     │thread_system│  │container_ │  │database_system│  Tier 1-2
+     │ (job queue, │  │system     │  │ (DB backend, │
+     │  pool)      │  │(serialize)│  │  interfaces) │
+     └──────┬─────┘  └─────┬─────┘  └──────┬───────┘
+            │               │               │
+            ▼               │               │
+     ┌──────────────┐      │               │
+     │network_system│      │               │
+     │ (TCP server) │ Tier 4               │
+     └──────┬───────┘      │               │
+            │               │               │
+            ▼               ▼               ▼
+     ┌─────────────────────────────────────────┐
+     │           database_server               │
+     │  (gateway middleware)                   │
+     └─────────────────────────────────────────┘
+
+     Optional: monitoring_system (Tier 3) for metrics export
+```
+
+### Dependency Roles
+
+| Dependency | Tier | Role in database_server |
+|------------|------|------------------------|
+| `common_system` | 0 | `Result<T>` for error handling, `IExecutor` for async execution, logging interfaces |
+| `thread_system` | 1 | Job scheduling, thread pool management, adaptive job queues |
+| `container_system` | 1 | Binary serialization for query protocol messages |
+| `database_system` | 2 | Database backend interfaces, connection types, query execution |
+| `network_system` | 4 | TCP server implementation (`messaging_server`) |
+| `monitoring_system` | 3 | Optional metrics export and health endpoint integration |
+
+## C++20 Module Structure
+
+The project supports C++20 modules for improved compilation times and encapsulation:
+
+```
+kcenon.database_server                    # Primary module interface
+│
+├── kcenon.database_server:core           # server_app, server_config
+├── kcenon.database_server:gateway        # gateway_server, query_router,
+│                                         # query_handlers, auth_middleware,
+│                                         # query_cache, query_protocol
+├── kcenon.database_server:pooling        # connection_pool, connection_types,
+│                                         # connection_priority, pool_metrics
+├── kcenon.database_server:resilience     # connection_health_monitor,
+│                                         # resilient_database_connection
+└── kcenon.database_server:metrics        # query_metrics_collector,
+                                          # query_collector_base
+```
+
+Each partition exports only its public API, providing clear module boundaries and preventing unintended internal dependencies.
+
+## Design Patterns
+
+### CRTP (Curiously Recurring Template Pattern)
+
+Used in two areas for zero-overhead polymorphism:
+
+1. **Query Handlers**: Seven handler types (select, insert, update, delete, execute, ping, batch) inherit from a CRTP base. A type erasure wrapper provides runtime polymorphism when dynamic dispatch is needed.
+
+2. **Metrics Collector**: `query_collector_base<Derived>` enables compile-time dispatch for metrics collection, following the pattern established by `monitoring_system`.
+
+### Result<T> Pattern
+
+All protocol operations and fallible functions return `Result<T>` from `common_system`, providing:
+- Type-safe error propagation without exceptions
+- Consistent error handling across all modules
+- Composable error chains
+
+### Configuration-Driven Architecture
+
+Server behavior is fully configurable via `config.conf` without code changes:
+- Network parameters (host, port, TLS, max connections)
+- Pool sizing (min/max connections, timeouts)
+- Authentication and rate limiting policies
+- Cache parameters (max entries, TTL, size limits)
+
+## Security Considerations
+
+### Authentication Flow
+
+1. Client connects via TCP and sends an `auth_token` in the first message
+2. `auth_middleware` validates the token using a pluggable validator
+3. Rate limiter checks per-client request rate
+4. On success, a secure session ID is generated and associated with the connection
+5. Subsequent requests reference the session for stateful operations
+
+### Session ID Security
+
+Session IDs use 128-bit cryptographic randomness:
+- Two 64-bit values from `std::random_device` (hardware entropy)
+- Thread-local `std::mt19937_64` seeded per-thread
+- Output: 32-character lowercase hexadecimal string
+- Verified: > 3.5 bits entropy per character across 100k samples
+
+---
+
+*Version: 1.0.0 | Last updated: 2026-02-22*


### PR DESCRIPTION
Closes #80

## Summary
- Add `README.kr.md` as a Korean translation of the existing `README.md`
- Add `docs/ARCHITECTURE.md` following the `thread_system` documentation pattern, covering system structure, core components, data flow, thread model, dependency graph, design patterns, and security considerations
- Add `docs/ARCHITECTURE.kr.md` as a Korean translation of the architecture documentation
- Add bidirectional language toggle links between all English and Korean document pairs

## Test Plan
- [x] Verify all language toggle links work correctly between document pairs
- [x] Verify no broken internal links in any document
- [x] Verify code blocks and technical identifiers remain in English in Korean documents
- [x] Verify Korean translations accurately reflect the English source content